### PR TITLE
Moved errant comma.

### DIFF
--- a/app/views/root/styleguide.html.erb
+++ b/app/views/root/styleguide.html.erb
@@ -605,7 +605,7 @@
         <ul>
           <li>government &ndash; never Government, even when referring to the elected administration, unless part of a specific name, eg Local Government Association, or Inside Government</li>
           <li>minister, never Minister, unless part of a specific job title, eg Minister for the Cabinet Office</li>
-          <li>department or ministry &ndash; never Department or Ministry, unless referring to a specific, one eg Ministry of Justice</li>
+          <li>department or ministry &ndash; never Department or Ministry, unless referring to a specific one, eg Ministry of Justice</li>
           <li>the titles of publications &ndash; only initial cap on first word and the entire title in single quote marks eg &lsquo;Implementing self-financing for council housing&rsquo; (unless it includes a phrase which should be capitalised for other reasons eg &lsquo;Review of the Right to Buy scheme&rsquo;)</li>
           <li>white paper, green paper, command paper, House of Commons paper</li>
           <li>director general (note no hyphen), deputy director, director unless in a specific job title</li>


### PR DESCRIPTION
The item "department or ministry – never Department or Ministry, unless referring to a specific, one eg Ministry of Justice" should be "department or ministry – never Department or Ministry, unless referring to a specific one, eg Ministry of Justice".
