### PR TITLE
Directgov national archives

### DIFF
--- a/app/views/root/designprinciples.html.erb
+++ b/app/views/root/designprinciples.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title do %>GDS design principles<% end %>
 
- <div id="wrapper" class="design-principles"> 
+ <div id="wrapper" class="design-principles">
   <div class="beta-notice">
     <div class="inner">
     <p>
@@ -16,77 +16,77 @@
      <ol>
        <li>
          <a href="#first">
-           <span class="icon">1</span> 
+           <span class="icon">1</span>
            <span class="caption">Start with needs*</span>
          </a>
        </li>
        <li>
          <a href="#second">
-           <span class="icon">2</span> 
+           <span class="icon">2</span>
            <span class="caption">Do less</span>
          </a>
        </li>
        <li>
          <a href="#third">
-           <span class="icon">3</span> 
+           <span class="icon">3</span>
            <span class="caption">Design with data</span>
          </a>
        </li>
        <li>
          <a href="#fourth">
-           <span class="icon">4</span> 
+           <span class="icon">4</span>
            <span class="caption">Do the hard work to make it simple</span>
          </a>
        </li>
        <li>
          <a href="#fifth">
-           <span class="icon">5</span> 
+           <span class="icon">5</span>
            <span class="caption">Iterate. Then iterate again.</span>
          </a>
        </li>
        <li>
          <a href="#sixth">
-           <span class="icon">6</span> 
+           <span class="icon">6</span>
            <span class="caption">Build for inclusion</span>
          </a>
        </li>
        <li>
          <a href="#seventh">
-           <span class="icon">7</span> 
+           <span class="icon">7</span>
            <span class="caption">Understand context</span>
          </a>
        </li>
        <li>
          <a href="#eighth">
-           <span class="icon">8</span> 
+           <span class="icon">8</span>
            <span class="caption">Build digital services, not websites</span>
          </a>
        </li>
        <li>
          <a href="#ninth">
-           <span class="icon">9</span> 
+           <span class="icon">9</span>
            <span class="caption">Be consistent, not uniform</span>
          </a>
        </li>
        <li>
          <a href="#tenth">
-           <span class="icon">10</span> 
+           <span class="icon">10</span>
            <span class="caption">Make things open: it makes things better</span>
          </a>
        </li>
      </ol>
    </nav>
-   
+
    <ol class="principles">
      <li class="principle">
        <article>
-       
+
         <hgroup>
           <h1 id="first">Start with needs*</h1>
           <h2>*user needs not government needs</h2>
         </hgroup>
 
-       
+
          <div class="outline">
            <p>
             The design process must start with identifying and thinking about real
@@ -95,7 +95,7 @@
             — interrogating data, not just making assumptions — and we should
             remember that what users ask for is not always what they need.</p>
          </div>
-         
+
          <section class="why">
            <div class="content">
              <p>We use ‘needs’ as an organising principle since people come to our
@@ -104,7 +104,7 @@
               most value for money.</p>
            </div>
          </section>
-         
+
          <section class="examples open-section">
            <h2>Examples</h2>
            <div class="content">
@@ -118,7 +118,7 @@
               </div>
               <div class="caption">
                 <p>If we start from the wrong place there’s no chance we will get the design right. Before we begin any project we spend a long time working out what the user needs are. <a href="http://digital.cabinetoffice.gov.uk/2011/09/19/introducing-the-needotron-working-out-the-shape-of-the-product/">This blog post explains a bit more about how we do that.</a></p>
-               
+
               </div>
             </article>
             <article class="process">
@@ -138,29 +138,29 @@
 
            </div>
          </section>
-         
+
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="second">Do less</h1>
-       
+
          <div class="outline">
            <p>Government should only do what only government can do. If someone else
             is doing it — link to it. If we can provide resources (like <a href="http://en.wikipedia.org/wiki/Application_programming_interface">APIs</a>)
             that will help other people build things — do that. We should
             concentrate on the irreducible core.</p>
          </div>
-         
+
          <section class="why">
            <div class="content">
              <p>We’ll make better services and save more money by focusing resources
               where they’ll do the most good.</p>
            </div>
          </section>
-         
+
          <section class="examples">
            <h2>Examples</h2>
            <div class="content">
@@ -177,18 +177,18 @@
                   <p>Remember that government should only do what only government can do, so while it’s right we should provide information about VAT it’s not necessary for us to provide information about <a href="http://webarchive.nationalarchives.gov.uk/20121015000000/www.direct.gov.uk/en/Environmentandgreenerliving/Smallholders/DG_179478">keeping bees</a>.</p>
                 </div>
               </article>
-  
+
            </div>
          </section>
-         
+
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="third">Design with data</h1>
-       
+
          <div class="outline">
            <p>Normally, we’re not starting from scratch — users are already using
             our services. This means we can learn from real world behaviour. We
@@ -197,7 +197,7 @@
             users on the live web. We should understand the desire paths of how we are designing with data and use
             them in our designs.</p>
          </div>
-         
+
          <section class="why">
            <div class="content">
              <p>This is the great advantage of digital services — we can watch and
@@ -206,7 +206,7 @@
               invented.</p>
            </div>
          </section>
-         
+
          <section class="examples">
            <h2>Examples</h2>
            <div class="content">
@@ -215,7 +215,7 @@
                   <h1>Examples of how we are designing with data</h1>
                   <p class="status experimental">Experimental</p>
                 </header>
-                
+
                 <div class="caption">
                   <p>Desire paths are a great way to understand what your user is trying to do.</p>
                   <p>You can read a great explanation of <a href="http://en.wikipedia.org/wiki/Desire_path">desire paths on wikipedia</a> as well as see some <a href="http://www.flickr.com/groups/desire_paths/pool/">examples in this flickr pool</a>.</p>
@@ -236,21 +236,21 @@
               </article>
            </div>
          </section>
-         
+
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="fourth">Do the hard work to make it simple</h1>
-       
+
          <div class="outline">
            <p>Making something look simple is easy; making something simple to use
             is much harder — especially when the underlying systems are complex —
             but that’s what we should be doing.</p>
          </div>
-         
+
          <section class="why">
            <div class="content">
              <p>With great power comes great responsibility — very often people have
@@ -258,7 +258,7 @@
               usable we’re abusing that power, and wasting people’s time.</p>
            </div>
          </section>
-         
+
          <section class="examples">
            <h2>Examples</h2>
            <div class="content">
@@ -277,31 +277,31 @@
               </article>
            </div>
          </section>
-         
+
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="fifth">Iterate. Then iterate again.</h1>
-       
+
          <div class="outline">
            <p>The best way to build effective services is to start small and iterate
             wildly. Release <a href="http://en.wikipedia.org/wiki/Minimum_viable_product">Minimum Viable Products</a> early, test them with real
             users, move from <a href="http://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha">Alpha</a> to <a href="http://en.wikipedia.org/wiki/Software_release_life_cycle#Beta">Beta</a> to Launch adding features and refinements based on feedback from real users.</p>
          </div>
-         
+
          <section class="why">
            <div class="content">
              <p>Iteration reduces risk. It makes big failures unlikely and turns small
               failures into lessons. This avoids the 200 page spec document
               which can turn into a bottleneck. This, again, is the core advantage of
               digital: we’re not building bridges — things can be undone.</p>
-             
+
            </div>
          </section>
-         
+
          <section class="examples">
            <h2>Examples</h2>
            <div class="content">
@@ -356,15 +356,15 @@ http://digital.cabinetoffice.gov.uk/2012/02/02/gov-uk-truly-open-platform/-->
 
            </div>
          </section>
-         
+
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="sixth">Build for inclusion</h1>
-       
+
          <div class="outline">
            <p>Accessible design is good design. We should build a product that’s as
             inclusive, legible and readable as possible. If we have to sacrifice
@@ -372,7 +372,7 @@ http://digital.cabinetoffice.gov.uk/2012/02/02/gov-uk-truly-open-platform/-->
             try to reinvent web design conventions and should set expectations
             clearly.</p>
          </div>
-         
+
          <section class="why">
            <div class="content">
              <p>We’re designing for the whole country — not just the ones who are used
@@ -381,7 +381,7 @@ http://digital.cabinetoffice.gov.uk/2012/02/02/gov-uk-truly-open-platform/-->
               people at the beginning we should make a better site for everyone.</p>
            </div>
          </section>
-         
+
          <section class="examples">
            <h2>Examples</h2>
            <div class="content">
@@ -503,22 +503,22 @@ No&lt;/label&gt;</code></pre>
               </article>
            </div>
          </section>
-         
+
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="seventh">Understand context</h1>
-       
+
          <div class="outline">
            <p>We’re not designing for a screen, we’re designing for people. We need
             to think hard about the context in which they’re using our services.
             Are they in a library? Are they on a phone? Are they only really
             familiar with Facebook? Have they never used the web before?</p>
          </div>
-         
+
          <section class="why">
            <div class="content">
              <p>We’re designing for a very diverse group of users with very different
@@ -528,7 +528,7 @@ No&lt;/label&gt;</code></pre>
               relevant to people’s lives.</p>
            </div>
          </section>
-         
+
          <section class="examples">
            <h2>Examples</h2>
            <div class="content">
@@ -547,15 +547,15 @@ No&lt;/label&gt;</code></pre>
               </article>
            </div>
          </section>
-         
+
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="eighth">Build digital services, not websites</h1>
-       
+
          <div class="outline">
            <p>Our service doesn’t begin and end at our website. It might start with
             a search engine and end at the post office. We need to design for
@@ -564,7 +564,7 @@ No&lt;/label&gt;</code></pre>
             again.</p>
 
          </div>
-         
+
          <section class="why">
            <div class="content">
              <p>We shouldn’t be about websites, we should be about digital services.
@@ -572,7 +572,7 @@ No&lt;/label&gt;</code></pre>
               but that might change, and sooner than we might expect.</p>
            </div>
          </section>
-         
+
          <section class="examples">
            <h2>Examples</h2>
            <div class="content">
@@ -587,15 +587,15 @@ No&lt;/label&gt;</code></pre>
               </article>
            </div>
          </section>
-         
+
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="ninth">Be consistent, not uniform</h1>
-       
+
          <div class="outline">
            <p>Wherever possible we should use the same language and the same design
             patterns — this helps people get familiar with our services. But, when
@@ -603,7 +603,7 @@ No&lt;/label&gt;</code></pre>
             consistent. So our users will have a reasonable chance of guessing
             what they’re supposed to do.</p>
          </div>
-         
+
          <section class="why">
            <div class="content">
              <p>This isn’t a straitjacket or a rule book. We can’t build great
@@ -614,7 +614,7 @@ No&lt;/label&gt;</code></pre>
               we move into new digital spaces.</p>
            </div>
          </section>
-         
+
          <section class="examples">
            <h2>Examples</h2>
            <div class="content">
@@ -633,15 +633,15 @@ No&lt;/label&gt;</code></pre>
 
            </div>
          </section>
-         
+
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="tenth">Make things open: it makes things better</h1>
-       
+
          <div class="outline">
            <p>We should share what we’re doing whenever we can. With colleagues,
             with users, with the world. Share code, share designs, share ideas,
@@ -649,7 +649,7 @@ No&lt;/label&gt;</code></pre>
             the better it gets — howlers get spotted, better alternatives get
             pointed out, the bar gets raised.</p>
          </div>
-         
+
          <section class="why">
            <div class="content">
              <p>Partly because much of what we’re doing is only possible because of
@@ -660,7 +660,7 @@ No&lt;/label&gt;</code></pre>
               away all this...</p>
            </div>
          </section>
-         
+
          <section class="examples">
            <h2>Examples</h2>
            <div class="content">
@@ -725,8 +725,8 @@ No&lt;/label&gt;</code></pre>
                   <p>Here are the icons we’ve used on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
                 </div>
               </article>
-              
-    
+
+
               <article class="process no-image">
                 <header>
                   <h1>Collaborative code</h1>
@@ -788,7 +788,7 @@ No&lt;/label&gt;</code></pre>
               </article>
            </div>
          </section>
-         
+
        </article>
      </li>
    </ol>
@@ -797,7 +797,7 @@ No&lt;/label&gt;</code></pre>
     <header>
       <h1>Feedback</h1>
     </header>
-    <p>This is an alpha release of the principles and we would like your feedback. Is there anything you think we should add that would make these principles more helpful? You can email your feedback to  
+    <p>This is an alpha release of the principles and we would like your feedback. Is there anything you think we should add that would make these principles more helpful? You can email your feedback to
     <a href="mailto:govuk-feedback@digital.cabinet-office.gov.uk">govuk-feedback@digital.cabinet-office.gov.uk</a>.</p>
   </section>
 </div>


### PR DESCRIPTION
Rather than pointing to the old (deprecated) URL for DirectGov on design principles, use the national archives (now canonical) link instead.
