### PR TITLE
bump slimmer to 3.9.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ end
 if ENV['SLIMMER_DEV']
   gem "slimmer", :path => '../slimmer'
 else
-  gem "slimmer", '1.2.3'
+  gem "slimmer", '3.9.4'
 end
 
 gem 'router-client', '~> 3.1.0', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,10 +47,6 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.0.11)
-    gds-api-adapters (0.2.2)
-      lrucache (~> 0.1.1)
-      null_logger
-      plek
     govuk_frontend_toolkit (0.3.3)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -65,7 +61,7 @@ GEM
     lograge (0.0.6)
       actionpack
       activesupport
-    lrucache (0.1.3)
+    lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
     mail (2.4.4)
       i18n (>= 0.4.0)
@@ -75,7 +71,7 @@ GEM
     multi_json (1.3.6)
     nokogiri (1.5.5)
     null_logger (0.0.1)
-    plek (0.3.0)
+    plek (0.5.0)
       builder
     polyglot (0.3.3)
     rack (1.4.1)
@@ -132,9 +128,9 @@ GEM
       libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
-    slimmer (1.2.3)
-      gds-api-adapters (>= 0.0.33, < 0.3.0)
+    slimmer (3.9.4)
       json
+      lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
       null_logger
       plek (>= 0.1.8)
@@ -172,7 +168,7 @@ DEPENDENCIES
   router-client (~> 3.1.0)
   rspec-rails (~> 2.11.0)
   sass-rails (~> 3.2.3)
-  slimmer (= 1.2.3)
+  slimmer (= 3.9.4)
   therubyracer
   uglifier (>= 1.0.3)
   unicorn (= 4.3.1)


### PR DESCRIPTION
slimmer 1.2.3 had a dependency on a really old version of gds-api-adapters. By bumping
to slimmer 3.9.4, we get rid of the old gds-api-adapters dependency, to smooth the process
to plek 1.0.0.
