### PR TITLE
bump Plek to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://gems.gemfury.com/vo6ZrmjBQu5szyywDszE/'
 
 gem 'rails', '3.2.6'
 gem 'unicorn', '4.3.1'
+gem 'plek', '1.0.0'
 gem 'govuk_frontend_toolkit', '0.3.3'
 
 # Gems used only for assets and not required
@@ -16,7 +17,7 @@ end
 if ENV['SLIMMER_DEV']
   gem "slimmer", :path => '../slimmer'
 else
-  gem "slimmer", '3.9.4'
+  gem "slimmer", '3.9.5'
 end
 
 gem 'router-client', '~> 3.1.0', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     multi_json (1.3.6)
     nokogiri (1.5.5)
     null_logger (0.0.1)
-    plek (0.5.0)
+    plek (1.0.0)
       builder
     polyglot (0.3.3)
     rack (1.4.1)
@@ -128,7 +128,7 @@ GEM
       libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
-    slimmer (3.9.4)
+    slimmer (3.9.5)
       json
       lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
@@ -164,11 +164,12 @@ DEPENDENCIES
   capybara (~> 1.1.2)
   govuk_frontend_toolkit (= 0.3.3)
   lograge
+  plek (= 1.0.0)
   rails (= 3.2.6)
   router-client (~> 3.1.0)
   rspec-rails (~> 2.11.0)
   sass-rails (~> 3.2.3)
-  slimmer (= 3.9.4)
+  slimmer (= 3.9.5)
   therubyracer
   uglifier (>= 1.0.3)
   unicorn (= 4.3.1)


### PR DESCRIPTION
And slimmer..which now uses correct Plek lookup (static, not assets).

Please read the Plek v1.0.0 [CHANGELOG](https://github.com/alphagov/plek/blob/master/CHANGELOG.md) to understand the implications.
