### PR TITLE
Avoid double bulleting on an `ol` list

### DIFF
--- a/app/views/root/performanceframework.html.erb
+++ b/app/views/root/performanceframework.html.erb
@@ -105,9 +105,9 @@
            <div class="content">
             <h2>Checklist</h2>
             <ol class="checklist">
-             <li><span class="icon">a.</span><span class="caption">Have you identified who your users are?</span></li>
-             <li><span class="icon">b.</span><span class="caption">Have you articulated your users’ needs?</span></li>
-             <li><span class="icon">c.</span><span class="caption">Have you prioritised services (e.g. by number of users or cost)?</span></li>
+             <li><span class="caption">Have you identified who your users are?</span></li>
+             <li><span class="caption">Have you articulated your users’ needs?</span></li>
+             <li><span class="caption">Have you prioritised services (e.g. by number of users or cost)?</span></li>
             </ol>
              <p>There is typically a hierarchy of interested users, all of whom
              will have different metrics for success. Technical staff might have
@@ -214,11 +214,11 @@
            <div class="content">
              <h2>Checklist</h2>
              <ol class="checklist">
-              <li><span class="icon">a.</span><span class="caption">Have you developed metrics and Key Performance Indicators (KPIs)?</span></li>
-              <li><span class="icon">b.</span><span class="caption">Are your metrics simple, actionable and collectable?</span></li>
-              <li><span class="icon">c.</span><span class="caption">Have you mapped your metrics to the relevant audience?</span></li>
-              <li><span class="icon">d.</span><span class="caption">Have you identified where your metrics will be sourced from?</span></li>
-              <li><span class="icon">e.</span><span class="caption">Do you know how frequently performance information is required by your users?</span></li>
+              <li><span class="caption">Have you developed metrics and Key Performance Indicators (KPIs)?</span></li>
+              <li><span class="caption">Are your metrics simple, actionable and collectable?</span></li>
+              <li><span class="caption">Have you mapped your metrics to the relevant audience?</span></li>
+              <li><span class="caption">Have you identified where your metrics will be sourced from?</span></li>
+              <li><span class="caption">Do you know how frequently performance information is required by your users?</span></li>
              </ol>
              <p>Key Performance Indicators (KPIs) will be few in number -
              typically around five - and are top-line indicators of how well a
@@ -442,12 +442,12 @@
            <div class="content">
             <h2>Checklist</h2>
              <ol class="checklist">
-              <li><span class="icon">a.</span><span class="caption">Have you installed web analytics software?</span></li>
-              <li><span class="icon">b.</span><span class="caption">Have you configured your web analytics software with the appropriate <a href="http://en.wikipedia.org/wiki/Conversion_funnel">conversion funnels</a>?</span></li>
-              <li><span class="icon">c.</span><span class="caption">Do you have the capability to run user satisfaction surveys?</span></li>
-              <li><span class="icon">d.</span><span class="caption">Do you have the capability to do <a href="http://en.wikipedia.org/wiki/Ab_testing">A/B testing</a> and <a href="http://en.wikipedia.org/wiki/Multivariate_testing">multivariate testing</a>?</span></li>
-              <li><span class="icon">e.</span><span class="caption">Do you have software installed for monitoring service uptime and performance?</span></li>
-              <li><span class="icon">f.</span><span class="caption">Can you generate custom performance data based on system-generated events?</span></li>
+              <li><span class="caption">Have you installed web analytics software?</span></li>
+              <li><span class="caption">Have you configured your web analytics software with the appropriate <a href="http://en.wikipedia.org/wiki/Conversion_funnel">conversion funnels</a>?</span></li>
+              <li><span class="caption">Do you have the capability to run user satisfaction surveys?</span></li>
+              <li><span class="caption">Do you have the capability to do <a href="http://en.wikipedia.org/wiki/Ab_testing">A/B testing</a> and <a href="http://en.wikipedia.org/wiki/Multivariate_testing">multivariate testing</a>?</span></li>
+              <li><span class="caption">Do you have software installed for monitoring service uptime and performance?</span></li>
+              <li><span class="caption">Can you generate custom performance data based on system-generated events?</span></li>
              </ol>
              <p>There are a number of open source products available as well as
              paid alternatives. If you are using a third party supplier, ensure
@@ -540,9 +540,9 @@
          <div class="content">
             <h2>Checklist</h2>
             <ol class="checklist">
-             <li><span class="icon">a.</span><span class="caption">Have you measured your current performance?</span></li>
-             <li><span class="icon">b.</span><span class="caption">Have you compared your performance with similar types of service (e.g. by transaction category)?</span></li>
-             <li><span class="icon">c.</span><span class="caption">Do you know who your users are in terms of age, disability, socio-economic group and internet usage?</span></li>
+             <li><span class="caption">Have you measured your current performance?</span></li>
+             <li><span class="caption">Have you compared your performance with similar types of service (e.g. by transaction category)?</span></li>
+             <li><span class="caption">Do you know who your users are in terms of age, disability, socio-economic group and internet usage?</span></li>
             </ol>
             <p>It is good practice to look at performance trends over time,
             rather than take a snapshot at a particular point in time. Peaks and
@@ -642,10 +642,10 @@
          <div class="content">
             <h2>Checklist</h2>
             <ol class="checklist">
-             <li><span class="icon">a.</span><span class="caption">Have you collected data on costs, usage and performance?</span></li>
-             <li><span class="icon">b.</span><span class="caption">Have you collected performance data from digital and non-digital channels?</span></li>
-             <li><span class="icon">c.</span><span class="caption">Do you know how many people use the service, by channel?</span></li>
-             <li><span class="icon">d.</span><span class="caption">Have you aggregated performance data to enable it to be easily combined?</span></li>
+             <li><span class="caption">Have you collected data on costs, usage and performance?</span></li>
+             <li><span class="caption">Have you collected performance data from digital and non-digital channels?</span></li>
+             <li><span class="caption">Do you know how many people use the service, by channel?</span></li>
+             <li><span class="caption">Have you aggregated performance data to enable it to be easily combined?</span></li>
             </ol>
             <p>Combining data often reveals useful insights, for example into
             service efficiency (eg cost per transaction and <a href="#total-cost-to-serve">total cost to serve</a>)
@@ -723,10 +723,10 @@
          <div class="content">
             <h2>Checklist</h2>
             <ol class="checklist">
-             <li><span class="icon">a.</span><span class="caption">Have you done any segmentation (i.e. analysed performance data by segment)?</span></li>
-             <li><span class="icon">b.</span><span class="caption">Have you designed the appropriate dashboards, reports and alerts?</span></li>
-             <li><span class="icon">c.</span><span class="caption">Are your data visualisations visible to their intended audience?</span></li>
-             <li><span class="icon">d.</span><span class="caption">Have you followed best practice design principles for data visualisation?</span></li>
+             <li><span class="caption">Have you done any segmentation (i.e. analysed performance data by segment)?</span></li>
+             <li><span class="caption">Have you designed the appropriate dashboards, reports and alerts?</span></li>
+             <li><span class="caption">Are your data visualisations visible to their intended audience?</span></li>
+             <li><span class="caption">Have you followed best practice design principles for data visualisation?</span></li>
             </ol>
             <p>Typical segments include:</p>
             <ul>
@@ -823,10 +823,10 @@
          <div class="content">
             <h2>Checklist</h2>
             <ol class="checklist">
-             <li><span class="icon">a.</span><span class="caption">Are you monitoring and acting upon user feedback?</span></li>
-             <li><span class="icon">b.</span><span class="caption">Have you done any <a href="http://en.wikipedia.org/wiki/A/B_testing">A/B testing</a> or <a href="http://en.wikipedia.org/wiki/Multivariate_testing">multivariate testing</a>?</span></li>
-             <li><span class="icon">c.</span><span class="caption">Have you evaluated the effectiveness of your performance reports?</span></li>
-             <li><span class="icon">d.</span><span class="caption">Have you taken an iterative approach to developing your service?</span></li>
+             <li><span class="caption">Are you monitoring and acting upon user feedback?</span></li>
+             <li><span class="caption">Have you done any <a href="http://en.wikipedia.org/wiki/A/B_testing">A/B testing</a> or <a href="http://en.wikipedia.org/wiki/Multivariate_testing">multivariate testing</a>?</span></li>
+             <li><span class="caption">Have you evaluated the effectiveness of your performance reports?</span></li>
+             <li><span class="caption">Have you taken an iterative approach to developing your service?</span></li>
             </ol>
             <p>Any service that meets user needs will include an element of user
             feedback. This should be monitored and acted upon so as to


### PR DESCRIPTION
Previous to this change, these lists had bullets like

    1. a. Lorem Ipsum
    2. b. Dolor Sit
    3. c. Etc....

I think it's more correct to either remove the extraneous 'a/b/c/...', or to use something other than an ordered list (`ol`).
### Screenshot of current behaviour on site

![Screen Shot 2013-03-01 at 09 28 08](https://f.cloud.github.com/assets/145/208950/5f931530-8252-11e2-828e-6d6d1db0f597.png)
