### PR TITLE
Bump toolkit to 3.32.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '3.2.13'
 gem 'unicorn', '4.3.1'
 gem 'lograge', '0.2.0'
 gem 'rack-rewrite', '1.3.3'
-gem 'govuk_frontend_toolkit', '0.12.1'
+gem 'govuk_frontend_toolkit', '0.32.2'
 gem 'plek', '1.1.0'
 gem 'router-client', '3.1.0', :require => false
 gem 'rummageable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    govuk_frontend_toolkit (0.12.1)
+    govuk_frontend_toolkit (0.32.2)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.1)
@@ -181,7 +181,7 @@ PLATFORMS
 DEPENDENCIES
   capybara (= 1.1.2)
   gds-api-adapters (= 7.1.0)
-  govuk_frontend_toolkit (= 0.12.1)
+  govuk_frontend_toolkit (= 0.32.2)
   lograge (= 0.2.0)
   mocha (= 0.13.3)
   plek (= 1.1.0)


### PR DESCRIPTION
Continuation of this work: https://github.com/alphagov/static/pull/270

Associated with (though they don't need to be merged simultaneously):

https://github.com/alphagov/business-support-finder/pull/31
https://github.com/alphagov/calendars/pull/37
https://github.com/alphagov/feedback/pull/53
https://github.com/alphagov/licence-finder/pull/36
https://github.com/alphagov/smart-answers/pull/466
https://github.com/alphagov/trade-tariff-frontend/pull/80
https://github.com/alphagov/transaction-wrappers/pull/28
