### PR TITLE
Handle the query string being empty

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -10,9 +10,14 @@ class SearchController < ApplicationController
 
     response.headers[Slimmer::Headers::SEARCH_PATH_HEADER] = '/service-manual/search'
 
-    res = search_client.search(params[:q], response_style: "hash")
     @search_term = params[:q]
-    @results = res["results"].map { |r| SearchResult.new(r) }
+
+    if params[:q].blank?
+      @results = []
+    else
+      res = search_client.search(params[:q], response_style: "hash")
+      @results = res["results"].map { |r| SearchResult.new(r) }
+    end
   rescue GdsApi::BaseError => e
     @results = ["HELP!"]
   end

--- a/spec/controller/search_controller_spec.rb
+++ b/spec/controller/search_controller_spec.rb
@@ -22,6 +22,11 @@ describe SearchController, :type => :controller do
     do_search
   end
 
+  it "should handle a blank query" do
+    controller.search_client.expects(:search).never
+    do_search('')
+  end
+
   it "should return unlimited results" do
     controller.search_client.stubs(:search)
                             .returns("results" => Array.new(75, {}))


### PR DESCRIPTION
We were returning an error becuase we expected the Rummager response to be a hash, but it was an array. This is because gds-api-adapters was returning the equivalent of 0 results if the query was blank, but didn't know about the newer response format.

design-principles has been broken in this respect since:
19d4ec72279f73138a77e092d278d49dbda6803f

Although it doesn't explicitly tell the user why they've got no results, it should make sense that blank query equals no results, so the UX feels fine to me.
