### PR TITLE
Remove unnecessary search parameters

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,7 +15,7 @@ class SearchController < ApplicationController
     if params[:q].blank?
       @results = []
     else
-      res = search_client.search(params[:q], response_style: "hash")
+      res = search_client.search(params[:q])
       @results = res["results"].map { |r| SearchResult.new(r) }
     end
   rescue GdsApi::BaseError => e

--- a/spec/controller/search_controller_spec.rb
+++ b/spec/controller/search_controller_spec.rb
@@ -17,7 +17,7 @@ describe SearchController, :type => :controller do
 
   it "should pass our query parameter in to the search client" do
     controller.search_client.expects(:search)
-                            .with("search-term", response_style: "hash")
+                            .with("search-term")
                             .returns("results" => []).once
     do_search
   end


### PR DESCRIPTION
These things are now the default, since:
https://github.com/alphagov/rummager/commit/1b0ab48073f758eb914c82471edee95c7e0477f2
