### PR TITLE
Update styleguide.html.erb

### DIFF
--- a/app/views/root/styleguide.html.erb
+++ b/app/views/root/styleguide.html.erb
@@ -18,7 +18,7 @@
         <p>The first part of this guide is for the whole of GOV.UK. Any information on <a href="https://www.gov.uk/">www.gov.uk</a> should follow this guidance.</p>
         <p>Then there are separate sections for the &lsquo;mainstream&rsquo; content (this is content for both businesses and citizens) and Inside Government content. These go over the different formats (eg the way we present the information) and include detail on specifics.</p>
         <h2 id="ever-changing-style-guide">Ever&#45;changing style guide</h2>
-        <p>This style guide will evolve &ndash; check <a href="https://www.gov.uk/designprinciples/styleguide">here</a> regularly for the up-to-date version.</p>
+        <p>This style guide will evolve &ndash; check back regularly for the up-to-date version.</p>
         <p>If there are style differences for separate sections of the site, you will see a &lsquo;style differences&rsquo; heading under the main content; if not, this style is to be used across the whole of GOV.UK.</p>
       </article>
     </li>


### PR DESCRIPTION
replacing "here" and related circular link with "back" and no link. Looks to be a legacy link from when the style guide existed elsewhere.
