### PR TITLE
H2 slugs changed to make anchor text linking logical

### DIFF
--- a/app/views/root/inside-government.html.erb
+++ b/app/views/root/inside-government.html.erb
@@ -17,7 +17,7 @@
         <p>The main GOV.UK style guide is at: <a href="https://www.gov.uk/designprinciples">www.gov.uk/designprinciples.</a></p>
         <p>GOV.UK is aimed at every citizen in the UK, and those outside of the UK with an interest in the UK government, but particularly those with a professional or personal interest in some aspect of government activity (eg an area of policy) or a part of government (eg an organisation or minister).</p>
 
-        <h2 id="ig-users">4.1 Inside Government users</h2>
+        <h2 id="inside-government-users">4.1 Inside Government users</h2>
         <p>Inside Government users usually prefer more in-depth information and some of the content has a specialist audience. However, we still need to get to the point of the information in a succinct, concise, usable way.</p>
 
         <p>There is no space for waffle anywhere on GOV.UK. </p>
@@ -62,18 +62,18 @@
         <h2 id="case-studies">5. Case studies</h2>
         <p>Case studies are real-world examples that show a need or outcome. Don&rsquo;t use them for details of programmes.</p>
 
-        <h2 id="titles-1">Titles</h2>
+        <h2 id="case-studies-titles">Titles</h2>
         <p>These can be more &lsquo;newsy&rsquo; than policy titles but should give the reader a clear idea of what they&rsquo;re going to get.</p>
         <p>Good example: UK money helps to build new homes in Darfur</p>
         <p>Bad example: After the war</p>
 
-        <h2 id="opening-paragraph">Opening paragraph</h2>
+        <h2 id="case-studies-opening-paragraph">Opening paragraph</h2>
         <p>One paragraph, 3 sentences or fewer. You want a short, sharp introduction that gives facts: what happened, why and the result.</p>
 
         <p>Good example:<br />
         &lsquo;The war in Darfur left many people without homes. We gave the Sudanese government &pound;x money and 500 builders to help build homes for 1,000 families.&rsquo;</p>
 
-        <h2 id="body-copy">Body copy</h2>
+        <h2 id="case-studies-body-copy">Body copy</h2>
         <p>There are no set headings but make sure you include specific facts about:</p>
         <ul>
           <li>how the case study supports a particular policy (include links to the policy/detail pages)</li>
@@ -87,22 +87,22 @@
         <p>&ldquo;It has made such a difference to our lives. My wife was ill and our children were getting sick. We were crammed into a tiny house with 5 other families. The living conditions were awful. Now we have a clean house to ourselves. The children share a room but they love the space and get up to mischief.&rdquo;&rsquo;</p>
         <p>Keep to the usual style. Explain any unusual terms and keep a friendly, informative tone. It&rsquo;s not a magazine and we won&rsquo;t be using slang etc but keep the language easy to understand.</p>
 
-        <h2 id="video">Video</h2>
+        <h2 id="case-studies-video">Video</h2>
         <p>You can use them. The format has to be: http://www.youtube/[filename]</p>
 
-        <h2 id="images-1">Images</h2>
+        <h2 id="case-studies-images">Images</h2>
         <p>The first image on the page will be placed automatically, top left. Subsequent images, and all videos, can be placed in the relevant part of the text using Markdown.</p>
 
-        <h2 id="quotes">Quotes</h2>
+        <h2 id="case-studies-quotes">Quotes</h2>
         <p>Include quotes but don&rsquo;t overload the page with them unless it is a straight interview. Use 5 or fewer. Use the quotation Markdown for each paragraph.</p>
 
-        <h2 id="background">Background</h2>
+        <h2 id="case-studies-background">Background</h2>
         <p>Giving context is important but don&rsquo;t overload the page with the past.</p>
 
-        <h2 id="about-us">6. Corporate pages: about us</h2>
+        <h2 id="corporate-pages-about-us">6. Corporate pages: about us</h2>
         <p>Tell users what your department actually <strong>does</strong>. Don&rsquo;t give mission statements and visions &ndash; tell users what you are actually doing for them and what you are responsible for.</p>
 
-        <h2 id="what-we-do">What we do</h2>
+        <h2 id="corporate-pages-what-we-do">What we do</h2>
         <p>Use &lsquo;we&rsquo; throughout &ndash; it should be very obvious who the &lsquo;we&rsquo; is on this page more than any other.</p>
         <p>Remember to:</p>
         <ul>
@@ -113,20 +113,20 @@
         </ul>
         <p>There are specific pages for you to give more detail, eg on energy use or governance. Keep this page short and concise.</p>
 
-        <h2 id="who-we-are">Who we are</h2>
+        <h2 id="corporate-pages-who-we-are">Who we are</h2>
         <p>A few lines about the number of staff you employ and where they are based.</p>
 
-        <h2 id="responsibilities">Responsibilities</h2>
+        <h2 id="corporate-pages-responsibilities">Responsibilities</h2>
         <p>Lead with &lsquo;We are responsible for:&rsquo; and bullet a list of your responsibilities. Keep them active, clear and not too detailed &ndash; you can do that in your policies.</p>
         <p>Maximum: 7 bullets.</p>
 
-        <h2 id="priorities">Priorities</h2>
+        <h2 id="corporate-pages-priorities">Priorities</h2>
         <p>Lead with: &lsquo;In 2012 and 2013, our priorities will be:&rsquo; (for this year, obviously. Change it next year.)</p>
         <p>It would be best if you took your main priorities based on your business plan &ndash; these are normally specific, clear and succinct.</p>
         <p>Maximum: 7 bullets.</p>
 
         <h2 id="corporate-pages-biographies">6.1. Corporate pages: biographies</h2>
-        <h2 id="ministerial-biographies">Ministerial biographies</h2>
+        <h2 id="corporate-pages-ministerial-biographies">Ministerial biographies</h2>
         <p>Remember to:</p>
         <ul>
           <li>keep it short; half a page is plenty for a bio</li>
@@ -140,19 +140,19 @@
         </ul>
         <p>Note: when talking about ministers who have previously held a role, use their first name and surname.</p>
 
-        <h2 id="management-biographies">Management biographies</h2>
+        <h2 id="corporate-pages-management-biographies">Management biographies</h2>
         <p>Use a maximum of 3 sentences to explain what the manager is doing and 5 bullets on career highlights.</p>
 
-        <h2 id="energy-use">6.2. Corporate pages: energy use</h2>
+        <h2 id="corporate-pages-energy-use">6.2. Corporate pages: energy use</h2>
         <p>Tell people which buildings you are monitoring and what you are doing to make sure energy use is efficient.</p>
         <p>Add a link to your energy efficiency certificate as a publication.</p>
         <p>Link to any third-party-hosted real-time energy data tools.</p>
 
-        <h2 id="personal-information-charter">6.3. Corporate pages: personal information charter</h2>
+        <h2 id="corporate-pages-personal-information-charter">6.3. Corporate pages: personal information charter</h2>
         <p>Lead with: &lsquo;Our personal information charter contains the standards you can expect when we ask for, or hold, your personal information. It also covers what we ask of you, to help us keep information up to date.&rsquo;</p>
         <p>There are no set headings but include why you ask for information, what you do with it and how users can ask to get copies of the information you hold about them. Look at <a href="https://www.gov.uk/government/organisations/department-for-transport/about/personal-information-charter">Department for Transport&rsquo;s personal charter</a> for an example.</p>
 
-        <h2 id="publication-scheme">6.4. Corporate pages: publication scheme</h2>
+        <h2 id="corporate-pages-publication-scheme">6.4. Corporate pages: publication scheme</h2>
         <p>Start by telling users what a publication scheme is. The opening paragraph should be:</p>
         <p>&lsquo;The publication scheme specifies the categories of information that the department and its agencies publish and explains how to get that information.&rsquo;</p>
         <p>Next, add all your publication links under these headings:</p>
@@ -180,12 +180,12 @@
         <p>Then you can go on to say that anything not published under the scheme can be requested under Freedom of Information and add your department&rsquo;s FOI contact details.</p>
         <p>End by giving users any additional information you want to include like pricing and contact details. There are no set headings at the moment but we will look at it in the summer of 2013.</p>
 
-        <h2 id="stats">6.5. Corporate pages: statistics at [department]</h2>
+        <h2 id="corporate-pages-statistics-at-department">6.5. Corporate pages: statistics at [department]</h2>
         <p>At the moment (April 2013), there&rsquo;s no set style for statistics &ndash; we are working on it.</p>
         <p>However, usual usability rules apply: orientate your user in the first paragraph and group your statistics under logical headings so the user can scan easily.</p>
         <p>Have a look at the <a href="https://www.gov.uk/government/organisations/department-of-energy-climate-change/about/statistics">Department of Energy and Climate Change page</a> as an example.</p>
 
-        <h2 id="working-with">6.6. Corporate pages: working with [department]</h2>
+        <h2 id="corporate-pages-working-with-department">6.6. Corporate pages: working with [department]</h2>
         <p>Again, no set headings but include:</p>
 
         <ul>
@@ -202,23 +202,23 @@
         <h2 id="consultations">7. Consultations</h2>
         <p>This is your chance to ask users to engage with government. Be specific, clear, open and findable.</p>
 
-        <h2 id="titles-2">Titles</h2>
+        <h2 id="consultations-titles">Titles</h2>
         <p>Use colons as connectors and use very plain language. If you have to use jargon or a reference number, make sure you also use plain English so all of your users will know if it is relevant for them.</p>
 
-        <h2 id="body-text">Body text</h2>
+        <h2 id="consultations-body-text">Body text</h2>
         <p>Give a short, succinct summary of what the consultation is asking people to comment on. Again, keep jargon to an absolute minimum. As government, we have to keep all users in mind. We can&rsquo;t exclude people by using unclear language.</p>
         <p>Keep it to under 100 words.</p>
 
-        <h2 id="attachments">Attachments</h2>
+        <h2 id="consultations-attachments">Attachments</h2>
         <p>When you upload the attachment it will automatically show the front page of the consultation. The type of document, number of pages and file size are captured automatically.</p>
         <p>The title field for this attachment will be displayed as the link text to download or open the file. This should be the full, official title of the publication as written on its front cover.</p>
         <p>When a government response is available, upload those files to the consultation page so that the whole consultation is findable at a single URL.</p>
 
-        <h2 id="news">8. News stories</h2>
+        <h2 id="news-stories">8. News stories</h2>
         <p>News content directly follows the common style guide, with the exceptions listed below.</p>
         <p>News shouldn&rsquo;t read like a press release &ndash; it should add value to a press release by increasing comprehensibility and user focus, and removing spin.</p>
 
-        <h2 id="titles-3">Titles</h2>
+        <h2 id="news-stories-titles">Titles</h2>
         <p>What is the actual story? Tell it in a few words.</p>
         <p>&lsquo;Minister visits factory&rsquo; is not a story. &lsquo;Vince Cable tells factory workers about workplace law reforms&rsquo; gives the reader a sense of what the story is about.</p>
         <p>Avoid &lsquo;teasing headlines&rsquo;, puns or wordplay &ndash; these make your story hard for people to find. Use the words most people use for the situation. This helps your search ranking.</p>
@@ -228,13 +228,13 @@
         <p>Bad example:<br />
         &lsquo;Girl goes into forest, encounters problems&rsquo;</p>
 
-        <h2 id="introductions">Introductions</h2>
+        <h2 id="news-stories-introductions">Introductions</h2>
 
-        <h2 id="summaries-1">Summaries</h2>
+        <h2 id="news-stories-summaries">Summaries</h2>
         <p>Summaries end with a full stop.</p>
         <p>Summaries do appear on news stories but not on other content types.</p>
 
-        <h2 id="body-copy-1">Body copy</h2>
+        <h2 id="news-stories-body-copy">Body copy</h2>
         <p>Introductions should be 15 to 50 words. Aim to tell the story in 1 or 2 sentences, eg who, what, where, when, why.</p>
         <p>Here&rsquo;s how to write effective body copy:</p>
 
@@ -247,17 +247,17 @@
           <li>use video and images</li>
         </ul>
 
-        <h2 id="sub-headers">Sub-headers</h2>
+        <h2 id="news-stories-sub-headers">Sub-headers</h2>
         <p>For news stories of fewer than than 150 words a sub-header below the introduction is discretionary.</p>
 
-        <h2 id="article-length">Article length</h2>
+        <h2 id="news-stories-article-length">Article length</h2>
         <p>No lower limit, although the value of a story under 150 words should be questioned.</p>
         <p>Upper limit of 750 words &ndash; with case-by-case exceptions (eg some Budget pages).</p>
 
-        <h2 id="quotes-1">Quotes</h2>
+        <h2 id="news-stories-quotes">Quotes</h2>
         <p>Do not include more than 2 consecutive sentences of quotes unless the quotation/speech is the story.</p>
 
-        <h2 id="policy">9. Policy pages</h2>
+        <h2 id="policy-pages">9. Policy pages</h2>
         <p>A policy is how the government plans to achieve a specific outcome.</p>
         <p>Policies on GOV.UK have 4 parts:</p>
         <ul>
@@ -267,7 +267,7 @@
           <li>supporting detail pages</li>
         </ul>
 
-        <h2 id="titles-4">Titles</h2>
+        <h2 id="policy-pages-titles">Titles</h2>
         <p>Policy titles should express the specific outcome the government is seeking to achieve. They should be:</p>
         <ul>
           <li>clear</li>
@@ -292,7 +292,7 @@
           <li>Tackling climate change</li>
         </ul>
 
-        <h2 id="issue-mandatory">Issue (mandatory)</h2>
+        <h2 id="policy-pages-issue-mandatory">Issue (mandatory)</h2>
         <p>This should answer the question &lsquo;why does the government have this policy?&rsquo;.</p>
         <p>Give a short, clear and specific description of the problem or opportunity and a brief explanation of what the government is going to do or is doing about it.</p>
         <p>This section isn&rsquo;t:</p>
@@ -305,7 +305,7 @@
         <p>&lsquo;The public sector &ndash; including central government, local councils and devolved administrations &ndash; accounts for around 3% of the UK&rsquo;s carbon emissions. In England alone, the government spends &pound;2.5 billion on energy for buildings and &pound;1.2 billion on owned-vehicle fuel.</p>
         <p>Improving energy efficiency in the public sector will result in a better use of taxpayers&rsquo; money and help the UK meet existing climate change agreements.&rsquo;</p>
 
-        <h2 id="actions-mandatory">Actions (mandatory)</h2>
+        <h2 id="policy-pages-actions-mandatory">Actions (mandatory)</h2>
         <p>This section details what the government is doing about the issue or to achieve the outcome in the policy title.</p>
         <p>Actions should be specific, measurable and time-bound.</p>
         <p>Summarise briefly what government is doing now and what it will do next &ndash; 1 short paragraph or bullet point for each action with links to supporting detail pages where relevant.</p>
@@ -317,7 +317,7 @@
           <li>make sure the goods, services and suppliers it chooses are energy efficient&rsquo;</li>
         </ul>
 
-        <h2 id="background-mandatory">Background (mandatory)</h2>
+        <h2 id="policy-pages-background-mandatory">Background (mandatory)</h2>
         <p>This section should explain how this policy and set of actions came about. Provide essential information for understanding the context of the policy, issue and actions.</p>
         <p>This isn&rsquo;t a dumping ground for information that doesn&rsquo;t fit the other headings, nor a history of everything, but a clear indication of how the policy got to where it is.</p>
         <p>Example:</p>
@@ -325,25 +325,25 @@
         <p>We commissioned research into y in 2010. This showed that that the most cost-effective and useful action we could take would be to do z.</p>
         <p>We consulted experts at an event in 2011 and worked with aaa and bbb to develop our action plan.&rsquo;</p>
 
-        <h2 id="who-were-consulting-or-who-weve-consulted-optional-and-depending-on-time">Who we&rsquo;re consulting or who we&rsquo;ve consulted (optional and depending on time)</h2>
+        <h2 id="policy-pages-who-were-consulting-or-who-weve-consulted-optional-and-depending-on-time">Who we&rsquo;re consulting or who we&rsquo;ve consulted (optional and depending on time)</h2>
         <p>Explain who has been or will be consulted or involved in the policy, and in what way.</p>
         <p>List any consultations &ndash; formal or informal. Give some detail about what is being done and by whom. Don&rsquo;t just add a list of links.</p>
         <p>Example:</p>
         <p>&lsquo;The government ran a consultation on &lsquo;Breaking the cycle: effective punishment, rehabilitation and sentencing of offenders&rsquo;. This set out our proposals for effectively punishing and rehabilitating offenders and reforming sentencing. Following that consultation, we revised our plans to xxx and yyy.&rsquo;</p>
 
-        <h2 id="impact-optional">Impact (optional)</h2>
+        <h2 id="policy-pages-impact-optional">Impact (optional)</h2>
         <p>List (and link inline to) any impact assessment publications.</p>
         <p>Briefly summarise the main points arising from the impact assessments.</p>
 
-        <h2 id="bills-and-legislation-optional">Bills and legislation (optional)</h2>
+        <h2 id="policy-pages-bills-and-legislation-optional">Bills and legislation (optional)</h2>
         <p>Give summary details of relevant legislation to explain the legal context for the policy and if the policy will mean changes to the law.</p>
         <p>Write full sentences, not just a list of related laws, and add links where relevant.</p>
 
-        <h2 id="who-we-are-working-with-optional">Who we are working with (optional)</h2>
+        <h2 id="policy-pages-who-we-are-working-with-optional">Who we are working with (optional)</h2>
         <p>List the organisations that have a major involvement, and what work is being done by them or with them.</p>
         <p>Write full sentences, don&rsquo;t just list the organisations.</p>
 
-        <h2 id="detail-pages-optional">Detail pages (optional)</h2>
+        <h2 id="policy-pages-detail-pages-optional">Detail pages (optional)</h2>
         <p>These pages are for users who want to know more about the actions listed on the cover sheet. So have 1 detail page for each action.</p>
         <p>They should provide supporting detail about the issue and actions.</p>
         <p>For example, if the actions include a programme costing &pound;x and running for 6 months, the detail page should provide further information about who is involved, what they are spending the money on and how.</p>
@@ -353,7 +353,7 @@
         <h2 id="publications">10. Publications</h2>
         <p>Publications are stand-alone documents. They are date-stamped and usually not updated once published. Don&rsquo;t use publications when you should be adding an attachment to another Inside Government format, for example: meeting minutes and agendas should be attachments.</p>
 
-        <h2 id="titles-5">Titles</h2>
+        <h2 id="publications-titles">Titles</h2>
         <p>Titles don&rsquo;t have to reflect the official publication title. Keep them short and search- and user-friendly.</p>
         <p>Front-load all titles &ndash; get all the most important words at the front of the sentence.</p>
         <p>Good example:<br />
@@ -370,19 +370,19 @@
         <p>Note: use acronyms, colons and truncated dates.</p>
 
 
-        <h2 id="summary-1">Summary</h2>
+        <h2 id="publications-summary">Summary</h2>
         <p>Give a short, 140 character summary and end with a full stop.</p>
 
-        <h2 id="body-text--what-its-for">Body text &ndash; what it&rsquo;s for</h2>
+        <h2 id="publications-body-text-what-its-for">Body text &ndash; what it&rsquo;s for</h2>
         <p>The body of a publication page is used to provide a summary of the publication in plain, neutral language &ndash; to reassure the user that it is (or isn&rsquo;t) what they&rsquo;re looking for. Include what the publication is about and its purpose. Publications often outlive governments so keep the language politically neutral.</p>
         <p>Include links to related publications but use series to group them if more than a few.</p>
         <p>Good example:<br />
         &lsquo;These reports describe the effect of government proposals to reduce the amount of money spent on legal aid. The aim of the reforms is to make sure legal aid is still available for support and representation in cases where it is justified.&rsquo;</p>
 
-        <h2 id="attachments--title-field">Attachments &ndash; title field</h2>
+        <h2 id="publications-attachments-title-field">Attachments &ndash; title field</h2>
         <p>Use the official title of the document.</p>
 
-        <h2 id="document-series">Document series</h2>
+        <h2 id="publications-document-series">Document series</h2>
         <p>The name of each document series should be concise, in plain English and have front-loaded keywords etc. Usual usability rules apply.</p>
         <p>It should not include the department name or acronym &ndash; transparency series are the only exception to this.</p>
         <p>Use the description field to:</p>


### PR DESCRIPTION
slugs are now:
- the name of the numbered section that H2 appears in, followed by
- all the words that appear in the title (ignoring all punctuation)

Example:
news-stories-titles
policy-pages-titles
publications-titles
and
policy-pages-who-were-consulting-or-who-weve-consulted-optional-and-depending-on-time
