### PR TITLE
Contract "it is" to "it's"

### DIFF
--- a/app/views/root/styleguide.html.erb
+++ b/app/views/root/styleguide.html.erb
@@ -69,20 +69,20 @@
    
         <p>We also lose trust from our users if we write government &lsquo;buzzwords&rsquo; and jargon. Often, these words are too general and vague and can lead to misinterpretation or empty, meaningless text. We can do without these words:</p>
         <ul>
-          <li>agenda (unless it is for a meeting)</li>
+          <li>agenda (unless it's for a meeting)</li>
           <li>advancing</li>
           <li>collaborate (use &lsquo;working with&rsquo;)</li>
           <li>combating</li>
           <li>commit/pledge (we need to be more specific &ndash; we&rsquo;re either doing something or we&rsquo;re not)</li>
           <li>countering</li>
           <li>deliver (pizzas, post and services are delivered &ndash; not abstract concepts like &lsquo;improvements&rsquo; or &lsquo;priorities&rsquo;)</li>
-          <li>deploy (unless it is military or software)</li>
+          <li>deploy (unless it's military or software)</li>
           <li>dialogue (we speak to people)</li>
           <li>disincentivise (and incentivise)</li>
           <li>empower</li>
           <li>facilitate (instead, say something specific about how you are helping)</li>
           <li>focusing</li>
-          <li>foster (unless it is children)</li>
+          <li>foster (unless it's children)</li>
           <li>impact (as a verb)</li>
           <li>initiate</li>
           <li>key (unless it unlocks something. A subject/thing isn&rsquo;t &lsquo;key&rsquo; &ndash; it&rsquo;s probably &lsquo;important&rsquo;)</li>
@@ -96,7 +96,7 @@
           <li>slimming down (processes don&rsquo;t diet &ndash; we are probably removing x amount of paperwork, etc)</li>
           <li>streamline</li>
           <li>strengthening (unless it&rsquo;s strengthening bridges or other structures)</li>
-          <li>tackling (unless it is rugby, football or some other sport)</li>
+          <li>tackling (unless it's rugby, football or some other sport)</li>
           <li>transforming (what are you actually doing to change it?)</li>
           <li>utilise</li>
         </ul>
@@ -104,7 +104,7 @@
 
         <ul>
           <li>drive (you can only drive vehicles; not schemes or people)</li>
-          <li>drive out (unless it is cattle)</li>
+          <li>drive out (unless it's cattle)</li>
           <li>going forward (unlikely we are giving travel directions)</li>
           <li>in order to (superfluous &ndash; don&rsquo;t use it)</li>
           <li>one-stop shop (we are government, not a retail outlet)</li>
@@ -132,7 +132,7 @@
         <p>Organise &ndash; not organize (this isn&rsquo;t actually an Americanism but is often seen as such).</p>
 
         <h2 id="ampersand">2.3 Ampersand</h2>
-        <p>Use &lsquo;and&rsquo; rather than an &lsquo;&amp;&rsquo;, unless it is the logo image on Inside Government.</p>
+        <p>Use &lsquo;and&rsquo; rather than an &lsquo;&amp;&rsquo;, unless it's the logo image on Inside Government.</p>
 
         <h2 id="brackets">2.4 Brackets</h2>
         <p>Use (round brackets), not [square brackets]. The only acceptable use of square brackets is for explanatory notes in reported speech, eg a minister&rsquo;s speech on Inside Government:</p>


### PR DESCRIPTION
This leapt out at me during the All Staff yesterday (I know). 

We advise using contractions – see 
https://www.gov.uk/designprinciples/styleguide#Singular-plural-and-contractions

My question to the Supreme Overlord – is there any reason why we should prefer "it is" over "it's"? 
