### PR TITLE
Disable travis email

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ rvm:
 matrix:
   allow_failures:
     - rvm: 2.0.0
+notifications:
+  email: false


### PR DESCRIPTION
I think most people just use the status in the pull request, so having
email sent isn't useful.
