### PR TITLE
Close door on ambiguity

### DIFF
--- a/app/views/root/styleguide.html.erb
+++ b/app/views/root/styleguide.html.erb
@@ -321,7 +321,7 @@
         <h2 id="money">2.18 Money</h2>
         <p>Use the &pound; symbol &ndash; &pound;75</p>
         <p>Don&rsquo;t use decimals unless pence are included &ndash; for example use: &pound;75.50 but not &pound;75.00.</p>
-        <p>Don&rsquo;t use &lsquo;&pound;0.xxm&rsquo; for amounts less than &pound;1 million.</p>
+        <p>Don&rsquo;t use &lsquo;&pound;0.xx million&rsquo; for amounts less than &pound;1 million.</p>
         <p>Write out &lsquo;pence&rsquo; in full &ndash; &lsquo;calls will cost 4 pence per minute from a landline&rsquo;.</p>
 
         <h2 id="organisations">2.19 Organisations</h2>


### PR DESCRIPTION
Don't encourage people to say '£1.3m' – prefer '£1.3 million'.

Seeking clarification on preferred usage before I clean up part of the service manual.
