### PR TITLE
Add internet to list of things to not capitalise

### DIFF
--- a/app/views/root/styleguide.html.erb
+++ b/app/views/root/styleguide.html.erb
@@ -57,8 +57,8 @@
           <li>not let caveats dictate unwieldy grammar &ndash; eg say &lsquo;You can&rsquo; rather than &lsquo;You may be able to&rsquo;</li>
           <li>use the language people are using &ndash; use Google Insights to check for terms people search for</li>
           <li>not use long sentences with complicated sub-clauses</li>
-          
         </ul>
+
         <p>(Note: words ending in &lsquo;&ndash;ion&rsquo; and &lsquo;&ndash;ment&rsquo; tend to make sentences longer and more complicated than they need to be.)</p>
        
         <h2 id="gender-neutral-text">1.4 Gender-neutral text</h2>
@@ -100,8 +100,8 @@
           <li>transforming (what are you actually doing to change it?)</li>
           <li>utilise</li>
         </ul>
-        <p>Always avoid metaphors. For example:</p>
 
+        <p>Always avoid metaphors. For example:</p>
         <ul>
           <li>drive (you can only drive vehicles; not schemes or people)</li>
           <li>drive out (unless it's cattle)</li>
@@ -194,6 +194,7 @@
           <li>departmental board, executive board, the board</li>
           <li>policy themes eg sustainable communities, promoting economic growth, local enterprise zones</li>
           <li>general mention of select committees (but DO cap specific ones &ndash; see above)</li>
+          <li>internet &ndash; rather than Internet</li>
         </ul>
 
         <h2 id="capitals-for-government-departments">Capitals for government departments</h2>


### PR DESCRIPTION
I would find it useful to have a reference for whether we should type Internet or internet because we do things with the internet occasionally here. Not sure if this is the right place: it's a list full of governmenty things.

(From https://github.com/alphagov/government-service-design-manual/pull/222/files#r6880803)
