### PR TITLE
Change made following content team edit

### DIFF
--- a/app/views/styleguide/answers.html.erb
+++ b/app/views/styleguide/answers.html.erb
@@ -43,12 +43,11 @@
           <li>use formatting options (eg callouts) but don't overload the page</li>
           </ul>
         <h2>When an answer becomes a guide</h2>
-        <p>When the answer:</p>
+        <p>WMake the answer part of a longer guide when:</p>
         <ul>
           <li>depends on too many things, for example the age of your child and the type of job can't be summed up</li>
           <li>is not a popular search</li>
         </ul>
-        <p>make it part of a longer guide</p>
       </article>
     </li>
   </ol>


### PR DESCRIPTION
When the answer:
depends on too many things, for example the age of your child and the type of job can't be summed up
is not a popular search
make it part of a longer guide
This should be rephrased so the lead-in captures the whole point, ie “Make the answer part of a longer guide when:”
