### PR TITLE
Users don't recognise words from shapes.

### DIFF
--- a/app/views/styleguide/writing-for-the-web.html.erb
+++ b/app/views/styleguide/writing-for-the-web.html.erb
@@ -63,7 +63,7 @@
           <h2 id="web-writing-how-users-read">How users read</h2>
           <p>Knowing how users read means you'll write in a way they can understand easily and quickly.</p>
           <p>By the time the average child is 9 years old, they can skip up to 30% of words on a page and still accurately predict the text. That's not just reading online. If there's enough context, the mind fills in the gaps. You don't need to read every word to understand what is written.</p>
-          <p>Also, online, users don't read in the traditional way. They don't necessarily read top to bottom or even from word to word. Their eyes bounce around the page and they don't necessarily even read the words – <a href="http://www.microsoft.com/typography/ctfonts/WordRecognition.aspx">they recognise them from their shapes</a>.</p>
+          <p>Also, online, users don't read in the traditional way. They don't necessarily read top to bottom or even from word to word.</p>
 
           <h2 id="web-writing-front-loading">Front-loadings</h2>
           <p>Web-user eye-tracking studies show that people tend to ‘read’ a webpage in an <a href="http://www.nngroup.com/articles/f-shaped-pattern-reading-web-content/">‘F’ shape pattern</a>. They look across the top, then down the side, reading further across when they find what they need.</p>


### PR DESCRIPTION
In fact the opposite is true, according to the very document used to support this statement. It says: "Word shape is no longer a viable model of word recognition."

_Detailed Explanation_

The link goes to http://www.microsoft.com/typography/ctfonts/WordRecognition.aspx 
The document starts with an informal introduction in which the author writes:

“There I learned to my chagrin that we recognize words from their word shape and that “Modern psychologists call this image the ‘Bouma shape.’” "

However, in the main paper the writer decribes a wide sweep of evidence and then concludes:

"Word shape is no longer a viable model of word recognition. The bulk of scientific evidence says that we recognize a word’s component letters, then use that visual information to recognize a word.”
