### PR TITLE
Removed comma

### DIFF
--- a/app/views/styleguide/style-points.html.erb
+++ b/app/views/styleguide/style-points.html.erb
@@ -118,6 +118,7 @@
             <li>tax year 2011 to 2012</li>
             <li>Monday to Friday, 9am to 5pm (put different days on a new line, don’t separate with a comma etc)</li>
             <li>10 November to 21 December</li>
+            <li>don't use a comma between the month and year, eg 14 June 2012</li>
             <li>when space is an issue, eg tables, publication titles etc, you can use truncated months, eg Jan, Feb, Mar, Aug, Sept, Oct, Nov, Dec</li>
             <li>5:30pm (not 1730hrs)</li>
             <li>midnight, not 00:00</li>
@@ -125,7 +126,8 @@
             <li>10am to 11am (not 10–11am)</li>
             <li>don’t use ‘quarter’ for dates; use the months, for example: ‘[dept] expenses, Jan to Mar 2013’</li>
           </ul>
-          <p>When referring to ‘today’ (eg in a news article) make sure you include the date as well. For example: ‘The minister announced today (14 June, 2012) that…’</p>
+          <p>When referring to ‘today’ (eg in a news article) make sure you include the date as well. For example: ‘The minister announced today (14 June 2012) that…’</p>
+          
 
           <h2>Eg, etc, and ie</h2>
           <p>Don’t use full stops after or between these notations.</p>


### PR DESCRIPTION
Removed comma in date 14 June, 2012 and added the point that we don't use a comma between the month and year in a date.
