### PR TITLE
Small grammar correction

### DIFF
--- a/app/views/styleguide/news-stories-and-press-releases.html.erb
+++ b/app/views/styleguide/news-stories-and-press-releases.html.erb
@@ -29,7 +29,7 @@
           </ul>
           <h3 id="news-stories-avoid-duplicating-press-releases">Avoid duplicating press releases</h3>
           <p>If you’ve already covered something in a press release, don’t put out a news story with the same information. It’s confusing for users, and means that both pages will perform less well in search.</p>
-          <h3 d="news-stories-avoid-duplication">Avoid duplicating other organisations’ news stories</h3>
+          <h3 id="news-stories-avoid-duplication">Avoid duplicating other organisations’ news stories</h3>
           <p>Any duplication is very obvious on GOV.UK, so stick to your remit.</p>
           <p>If there’s more than one organisation with an interest in a topical issue, think about producing a joint story – it’s likely to have more impact.</p>
           <p>But if two organisations are covering completely different angles and/or addressing different audiences, it’s okay to issue separate stories.</p>
@@ -42,7 +42,7 @@
           </ul>
           <p>Content that’s more about providing comment or explaining the government’s position on a matter of policy is probably more suitable for a press release. Content that’s about explaining the government’s position in response to something in the news is probably better published as a ‘Government response’.</p>
           <h3 id="news-stories-genuine-content">Make sure it’s genuine news content</h3>
-          <p>Genuine news content should is self-contained: it should be possible to delete it from the site without affecting anything else. Don’t publish news stories that are actually general purpose content pages.</p>
+          <p>Genuine news content should be self-contained: it should be possible to delete it from the site without affecting anything else. Don’t publish news stories that are actually general purpose content pages.</p>
           <p>Also, news stories represent the organisation’s views at a particular moment in time: don’t make changes after they’re published, unless it’s to correct an error.</p>
           <h3>Make sure it adds something to existing content</h3>
           <p>Don’t publish news items just to provide a link through to other GOV.UK content – it confuses user journeys and complicates search results, without adding any benefit for users.</p>


### PR DESCRIPTION
Changed is to be
Conflicts:
    app/views/styleguide/news-stories-and-press-releases.html.erb

Also fixes `id` attribute typo from previous commit.
