### PR TITLE
Reinstated plain English is mandatory

### DIFF
--- a/app/views/styleguide/writing-for-govuk.html.erb
+++ b/app/views/styleguide/writing-for-govuk.html.erb
@@ -65,7 +65,7 @@
           <p>We’ve had <a href="https://www.gov.uk/government/publications/govuk-content-principles-conventions-and-research-background">research done on the impact of style guides</a>. Have a look.</p>
 
           <h2 id="writing-plain-english">Plain English</h2>
-          <p id="plain-english--mandatory-for-all-of-govuk">One of the parts <a href="http://www.independent.co.uk/news/uk/politics/only-pizzas-are-delivered-public-sector-jargon-banned-in-first-style-guide-for-government-announcements-8730020.html">most people pick up on</a> is the plain English list.</p>
+          <p>Plain English is mandatory for all of GOV.UK. One of the arts most people pick up on is the <a href="http://www.independent.co.uk/news/uk/politics/only-pizzas-are-delivered-public-sector-jargon-banned-in-first-style-guide-for-government-announcements-8730020.html">plain English list</a>.</p>
           <p>This isn’t just a list of words to avoid. Plain English is the whole ethos of GOV.UK; it’s a way of writing.</p>
           <p>The list isn’t exhaustive. It’s an indicator to show you the sort of language that confuses.</p>
           <p>GOV.UK is for everyone. Users don’t stop understanding text because it’s written clearly. Less educated users may not understand if you use difficult language.</p>


### PR DESCRIPTION
This sentence "Plain English is mandatory for all of GOV.UK" had been corrupted in the code so was absent from the published text. Have also put the proceeding link in better link text.
