### PR TITLE
removed ATWD entry

### DIFF
--- a/db/a-z.csv
+++ b/db/a-z.csv
@@ -4,7 +4,6 @@ Accounts office,This is an official title.
 Activation PIN,"Title case. 'Activation PIN' has been changed to 'Activation Code' on outgoing correspondence from the Government Gateway. Until all hard coded instances of Activation PIN have been removed from the Online Services pages, use:
 'Activation Code (also known as Activation PIN)'."
 "act, act of Parliament ","Lower case. Only cap up when using the full title, eg Planning and Compulsory Purchase Act 2004. "
-Alcohol and Tobacco Warehousing Declaration (ATWD),"In full the first time, then use 'the declaration'."
 al-Qa'ida,
 animal health,Lower case.
 antisocial,No hyphen.


### PR DESCRIPTION
This doesn't need its own entry as it follows the normal style guide acronym rule.
