### PR TITLE
Use consistent punctuation for eg

### DIFF
--- a/app/views/styleguide/detailed-guides.html.erb
+++ b/app/views/styleguide/detailed-guides.html.erb
@@ -23,7 +23,7 @@
             <li>make sure the title provides a full context (also helpful for search)</li>
           </ul>
           <p>For example: 'guidance for potato growers', not 'potatoes'.</p>
-          <p>If there are a number of guides with a repeated phrase in the title (eg Manufactured goods: automotive, Manufactured goods: electronic) change the title so that the most important area is front-loaded eg 'Automotive sector: import and export regulations' or 'Chemical sector: import and export regulations'. This is more descriptive and useful for search.</p>
+          <p>If there are a number of guides with a repeated phrase in the title (eg Manufactured goods: automotive, Manufactured goods: electronic) change the title so that the most important area is front-loaded, eg 'Automotive sector: import and export regulations' or 'Chemical sector: import and export regulations'. This is more descriptive and useful for search.</p>
           <h2 id="detailed-guides-summaries">Summaries</h2>
           <p>Use the summary to orientate the user to the page by:</p>
           <ul>

--- a/app/views/styleguide/news-stories-and-press-releases.html.erb
+++ b/app/views/styleguide/news-stories-and-press-releases.html.erb
@@ -57,7 +57,7 @@
           </ul>
           <p>‘Minister visits factory’ is not a story. ‘Vince Cable tells factory workers about workplace law reforms’ gives the reader a sense of what the story is about.</p>
           <p>Avoid ‘teasing headlines’, puns or wordplay – these make your story hard for people to find. Use the words most people use for the situation. This helps your search ranking.</p>
-          <p>Avoid print conventions / ‘journalese’ eg ‘Minister in youth homelessness bid’ (‘bid’ is used in print where headline space is in short supply).</p>
+          <p>Avoid print conventions / ‘journalese’, eg ‘Minister in youth homelessness bid’ (‘bid’ is used in print where headline space is in short supply).</p>
           <p>Think about what happens in Little Red Riding Hood, then think what the headline should be:</p>
           <p>Good example: ‘Granny in near-death wolf escape’</p>
           <p>Bad example: ‘Girl goes into forest, encounters problems’</p>

--- a/app/views/styleguide/people-and-roles.html.erb
+++ b/app/views/styleguide/people-and-roles.html.erb
@@ -50,7 +50,7 @@
             <li>keep it short; half a page is plenty for a bio</li>
             <li>lead with: '[name] was appointed [title] in [date]. [He/she] is the [party] MP for [constituency]'</li>
             <li>first name terms: The Rt Hon Nick Clegg MP at the top of the page, then use Nick Clegg at first mention, then Nick</li>
-            <li>a Lord or Baroness will always use their title and surname eg Baroness Warsi</li>
+            <li>a Lord or Baroness will always use their title and surname, eg Baroness Warsi</li>
             <li>education: avoid 'read'; use 'studied'</li>
             <li>political career: a few sentences of career highlights in chronological order; if this is long, use bullet points, with an introductory sentence</li>
             <li>career outside politics: if none, use 'Political career'</li>

--- a/app/views/styleguide/style-points.html.erb
+++ b/app/views/styleguide/style-points.html.erb
@@ -64,13 +64,13 @@
             <li>brand names</li>
             <li>The Earth (ie our planet), Planet Earth and Earth sciences</li>
             <li>faculties, departments, institutes and schools</li>
-            <li>job titles, ministers’ role titles eg Minister for Housing, Home Secretary</li>
-            <li>names of groups, directorates and organisations eg Knowledge and Innovation Group</li>
+            <li>job titles, ministers’ role titles, eg Minister for Housing, Home Secretary</li>
+            <li>names of groups, directorates and organisations, eg Knowledge and Innovation Group</li>
             <li>Parliament, the House</li>
             <li>titles of specific acts or bills, eg Housing Reform Bill (but use ‘the act’ or ‘the bill’ after the first time you use the full act or bill title)</li>
-            <li>names of specific, named government schemes known to people outside government eg Right to Buy, Queen’s Awards for Enterprise</li>
+            <li>names of specific, named government schemes known to people outside government, eg Right to Buy, Queen’s Awards for Enterprise</li>
             <li>Rt Hon (note lack of full stops)</li>
-            <li>specific select committees (eg Public Administration Select Committee)</li>
+            <li>specific select committees, eg Public Administration Select Committee</li>
             <li>header cells in tables</li>
             <li>titles of publications (and within single quotes)</li>
             <li>World War 1 and World War 2 (note caps and numbers)</li>
@@ -86,7 +86,7 @@
             <li>director general (note no hyphen), deputy director, director, unless in a specific job title</li>
             <li>group and directorate, unless referring to a specific group or directorate, eg the Commercial Directorate</li>
             <li>departmental board, executive board, the board</li>
-            <li>policy themes eg sustainable communities, promoting economic growth, local enterprise zones</li>
+            <li>policy themes, eg sustainable communities, promoting economic growth, local enterprise zones</li>
             <li>general mention of select committees (but do cap specific ones – see above)</li>
           </ul>
 
@@ -232,7 +232,7 @@
           <p>Use the block quote markdown for quotes longer than a few sentences.</p>
 
           <h2 id="style-contractions">Contractions</h2>
-          <p>Use contractions eg ‘they’ve’, ‘we’ll’. Avoid using ‘should’ve’, ‘could’ve’, ‘would’ve’ etc – these are hard to read.</p>
+          <p>Use contractions, eg ‘they’ve’, ‘we’ll’. Avoid using ‘should’ve’, ‘could’ve’, ‘would’ve’ etc – these are hard to read.</p>
 
           <h2 id="style-spaces">Spaces</h2>
           <p>Use only 1 space after a full stop, not 2.</p>


### PR DESCRIPTION
We had a mixture of prefixing with '-', '–', ':', ' ' and ','.

Removed instances where we just had a space.
