### PR TITLE
Add redirect for mis-spelled URL

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -43,6 +43,7 @@ namespace :router do
       ["/service-manual/user-centered-design/writing-government-services.html", "exact", "/service-manual/content-designers/transactions-style-guide"],
       ["/service-manual/user-centered-design/what-should-service-look-like", "exact", "/service-manual/user-centered-design/service-look-and-feel"],
       ["/service-manual/user-centered-design/what-should-service-look-like.html", "exact", "/service-manual/user-centered-design/service-look-and-feel"],
+      ["/service-manual/user-centered-design/user-research/guerilla-testing", "prefix", "/service-manual/user-centered-design/user-research/guerrilla-testing"],
     ].each do |path, type, destination|
       begin
         @logger.info "Registering #{type} redirect route from #{path} -> #{destination}"


### PR DESCRIPTION
Depends on alphagov/government-service-design-manual#329 being merged and
compiled first.
