### PR TITLE
Add guidance on abbreviating million/billion

### DIFF
--- a/app/views/styleguide/style-points.html.erb
+++ b/app/views/styleguide/style-points.html.erb
@@ -192,8 +192,9 @@
           <p>Keep it as accurate as possible and up to 2 decimal places. For example: 4.03MB.</p>
           <p>Addresses: use ‘to’ in address ranges, for example: 49 to 53 Cherry Street.</p>
 
-          <h2 id="style-millions">Millions</h2>
-          <p>Always use million in money (and billion), eg £138 million. Use millions in phrases, eg ‘millions of people’.</p>
+          <h2 id="style-millions">Millions and billions</h2>
+          <p>Always use million (and billion) in money, eg £138 million. Use millions in phrases, eg ‘millions of people’.</p>
+          <p>Spell out million or billion in full wherever possible. Abbreviate million to ‘m’ and billion to ‘bn’ if space is at a premium (like in tables), eg ‘£6m’ or ‘£52bn’.</p>
 
           <h2 id="style-ordinals">Ordinal numbers</h2>
           <p>Spell out first to ninth. After that use 10th, etc.</p>


### PR DESCRIPTION
We had a story recently to change our abbreviation for billion from 'b' to 'bn'. As with most things, I don't really mind what the specific outcome of this pull request is, I'd just like it to be documented. This should be signed off by somebody who knows what they're doing with content (ie not me).

This follows the Guardian style guide:
- http://www.theguardian.com/guardian-observer-style-guide-b
- http://www.theguardian.com/guardian-observer-style-guide-m
