### PR TITLE
Add distinct page titles

### DIFF
--- a/app/views/styleguide/a-z.html.erb
+++ b/app/views/styleguide/a-z.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>A to Z - GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – A to Z<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/answers.html.erb
+++ b/app/views/styleguide/answers.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Answers<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/benefits-and-schemes.html.erb
+++ b/app/views/styleguide/benefits-and-schemes.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Benefits and schemes<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/case-studies.html.erb
+++ b/app/views/styleguide/case-studies.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Case studies<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/consultations.html.erb
+++ b/app/views/styleguide/consultations.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Consultations<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/corporate-information.html.erb
+++ b/app/views/styleguide/corporate-information.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Corporate information<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/detailed-guides.html.erb
+++ b/app/views/styleguide/detailed-guides.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Detailed guides<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/government-responses.html.erb
+++ b/app/views/styleguide/government-responses.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Government responses<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/guides.html.erb
+++ b/app/views/styleguide/guides.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Guides<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/images.html.erb
+++ b/app/views/styleguide/images.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Images<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/news-stories-and-press-releases.html.erb
+++ b/app/views/styleguide/news-stories-and-press-releases.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – News stories and press releases<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/organisation-homepage.html.erb
+++ b/app/views/styleguide/organisation-homepage.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Organisation homepage<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/people-and-roles.html.erb
+++ b/app/views/styleguide/people-and-roles.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – People and roles<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/policy-advisory-groups.html.erb
+++ b/app/views/styleguide/policy-advisory-groups.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Policy advisory groups<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/policy-pages.html.erb
+++ b/app/views/styleguide/policy-pages.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Policy pages<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/publications.html.erb
+++ b/app/views/styleguide/publications.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Publications<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/speeches.html.erb
+++ b/app/views/styleguide/speeches.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Speeches<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/statements-to-parliament.html.erb
+++ b/app/views/styleguide/statements-to-parliament.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Statements to Parliament<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/style-points.html.erb
+++ b/app/views/styleguide/style-points.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Style points<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/whats-new.html.erb
+++ b/app/views/styleguide/whats-new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – What's new<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <header>

--- a/app/views/styleguide/writing-for-govuk.html.erb
+++ b/app/views/styleguide/writing-for-govuk.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>

--- a/app/views/styleguide/writing-for-the-web.html.erb
+++ b/app/views/styleguide/writing-for-the-web.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>GDS design principles<% end %>
+<% content_for :title do %>GOV.UK – Style guide – Writing for the web<% end %>
 
 <div id="wrapper" class="design-principles styleguide">
   <%= render "styleguide_description" %>


### PR DESCRIPTION
Should have better SEO properties in terms of being easier to understand what
each page is about in SERPs.

https://www.google.co.uk/search?q=gov+uk has a first result of 'Welcome to GOV.UK'. This is the html page `<title/>` element

https://www.google.co.uk/search?q=gov+uk+style+guide has a first result of 'Style Guide - Gov.UK'. This is not the html page `<title/>` element, which is in fact `<title>GDS design principles</title>`

If we fix the title, we may have the correct search results*.
