### PR TITLE
snap link - content is now on GOV.UK

### DIFF
--- a/app/views/styleguide/writing-for-govuk.html.erb
+++ b/app/views/styleguide/writing-for-govuk.html.erb
@@ -118,7 +118,7 @@
           <p>Write conversationally – picture your audience and write as if you were talking to them one-to-one but with the authority of someone who can actively help.</p>
 
           <h2 id="writing-inclusive-language">Inclusive language</h2>
-          <p><a href="http://odi.dwp.gov.uk/inclusive-communications/representation/language.php">Words to use and avoid when writing about disability</a>.
+          <p><a href="https://www.gov.uk/government/publications/inclusive-communication/inclusive-language-words-to-use-and-avoid-when-writing-about-disability--2">Words to use and avoid when writing about disability</a>.
 
           <h2 id="writing-search-results">Search results</h2>
           <p id="seo">We need to get government information to where the UK public can find it. We use search engine optimisation (SEO) to get users to the content that meets their need as quickly and effortlessly as possible. Our goal isn't 'high traffic', it's 'the right traffic'.</p>


### PR DESCRIPTION
The old link 301s to the new link, so this isn't urgent, just a bit of cleanup.
