### PR TITLE
Bump slimmer to 8.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'gds-api-adapters', '7.18.0'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '3.25.0'
+  gem 'slimmer', '8.1.0'
 end
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,12 +144,12 @@ GEM
       libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
-    slimmer (3.25.0)
+    slimmer (8.1.0)
+      activesupport
       json
-      lrucache (~> 0.1.3)
-      nokogiri (~> 1.5.0)
+      nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
-      plek (>= 0.1.8)
+      plek (>= 1.1.0)
       rack (>= 1.3.5)
       rest-client
     sprockets (2.2.2)
@@ -196,7 +196,7 @@ DEPENDENCIES
   rspec-rails (= 2.11.0)
   rummageable
   sass-rails (= 3.2.5)
-  slimmer (= 3.25.0)
+  slimmer (= 8.1.0)
   therubyracer (= 0.12.1)
   thin
   uglifier (= 1.2.6)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,15 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
+  before_filter :turn_off_report_a_problem
 
 protected
   def set_expiry(duration = 30.minutes)
     unless Rails.env.development?
       expires_in(duration, :public => true)
     end
+  end
+
+  def turn_off_report_a_problem
+    response.headers[Slimmer::Headers::REPORT_A_PROBLEM_FORM] = "false"
   end
 end


### PR DESCRIPTION
This picks up the analytics change which sets metadata in the head tag,
rather than generating Javascript to send custom dimensions.