### PR TITLE
Use unified search endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ gem 'logstasher', '0.4.8'
 gem 'rack-rewrite', '1.3.3'
 gem 'govuk_frontend_toolkit', '1.4.0'
 gem 'plek', '1.5.0'
-gem 'rummageable'
-gem 'gds-api-adapters', '7.18.0'
+gem 'rummageable', '1.2.0'
+gem 'gds-api-adapters', '18.3.0'
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,21 +46,26 @@ GEM
       ffi (~> 1.0.6)
     daemons (1.1.9)
     diff-lcs (1.1.3)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     eventmachine (1.0.3)
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.0.11)
-    gds-api-adapters (7.18.0)
+    gds-api-adapters (18.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
-      rest-client (~> 1.6.3)
+      rack-cache
+      rest-client (~> 1.8.0)
     govuk_frontend_toolkit (1.4.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.3)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.6.9)
     journey (1.0.4)
     json (1.8.1)
@@ -68,7 +73,7 @@ GEM
     libv8 (3.16.14.3)
     libwebsocket (0.1.3)
       addressable
-    link_header (0.0.7)
+    link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.4.8)
       logstash-event (~> 1.1.0)
@@ -82,6 +87,7 @@ GEM
     mocha (0.13.3)
       metaclass (~> 0.0.1)
     multi_json (1.8.4)
+    netrc (0.10.3)
     nokogiri (1.5.5)
     null_logger (0.0.1)
     plek (1.5.0)
@@ -114,8 +120,10 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     ref (1.0.5)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -130,9 +138,9 @@ GEM
       railties (>= 3.0)
       rspec (~> 2.11.0)
     rubyzip (0.9.9)
-    rummageable (0.6.2)
-      json
-      plek (>= 0.5.0)
+    rummageable (1.2.0)
+      multi_json
+      null_logger
       rest-client
     sass (3.4.7)
     sass-rails (3.2.5)
@@ -173,6 +181,9 @@ GEM
     uglifier (1.2.6)
       execjs (>= 0.3.0)
       multi_json (~> 1.3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.6)
     unicorn (4.3.1)
       kgio (~> 2.6)
       rack
@@ -186,7 +197,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 3.1.17)
   capybara (= 1.1.2)
-  gds-api-adapters (= 7.18.0)
+  gds-api-adapters (= 18.3.0)
   govuk_frontend_toolkit (= 1.4.0)
   logstasher (= 0.4.8)
   mocha (= 0.13.3)
@@ -194,7 +205,7 @@ DEPENDENCIES
   rack-rewrite (= 1.3.3)
   rails (= 3.2.20)
   rspec-rails (= 2.11.0)
-  rummageable
+  rummageable (= 1.2.0)
   sass-rails (= 3.2.5)
   slimmer (= 8.1.0)
   therubyracer (= 0.12.1)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -12,10 +12,10 @@ class SearchController < ApplicationController
 
     @search_term = params[:q]
 
-    if params[:q].blank?
+    if @search_term.blank?
       @results = []
     else
-      res = search_client.search(params[:q])
+      res = search_client.unified_search(q: @search_term, filter_manual: "service-manual")
       @results = res["results"].map { |r| SearchResult.new(r) }
     end
   rescue GdsApi::BaseError => e
@@ -25,7 +25,7 @@ class SearchController < ApplicationController
   protected
 
   def search_client
-    @search_client ||= GdsApi::Rummager.new(Plek.current.find('search') + '/service-manual')
+    @search_client ||= GdsApi::Rummager.new(Plek.current.find('rummager'))
   end
 
   def set_expiry(duration = 30.minutes)

--- a/lib/search_result.rb
+++ b/lib/search_result.rb
@@ -19,8 +19,12 @@ class SearchResult
     @result = result.stringify_keys!
   end
 
+  def title
+    result["title"].gsub(/\AGovernment Service Design Manual: /, '')
+  end
+
   PASS_THROUGH_KEYS = [
-    :presentation_format, :link, :title, :description,
+    :presentation_format, :link, :description,
     :format, :humanized_format
   ]
   PASS_THROUGH_KEYS.each do |key|

--- a/spec/controller/search_controller_spec.rb
+++ b/spec/controller/search_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 
 describe SearchController, :type => :controller do
   def stub_client
-    stub_search_client = stub("search", search: { "results" => [] })
+    stub_search_client = stub("search", unified_search: { "results" => [] })
     controller.stubs(:search_client).returns(stub_search_client)
   end
 
@@ -16,8 +16,8 @@ describe SearchController, :type => :controller do
   end
 
   it "should pass our query parameter in to the search client" do
-    controller.search_client.expects(:search)
-                            .with("search-term")
+    controller.search_client.expects(:unified_search)
+                            .with(q: "search-term", filter_manual: "service-manual")
                             .returns("results" => []).once
     do_search
   end
@@ -28,7 +28,7 @@ describe SearchController, :type => :controller do
   end
 
   it "should return unlimited results" do
-    controller.search_client.stubs(:search)
+    controller.search_client.stubs(:unified_search)
                             .returns("results" => Array.new(75, {}))
 
     do_search('Test')


### PR DESCRIPTION
This functions very similarly to the old endpoint, but also requires
stripping the common leading prefix of the manual name from each result.

It also requires updating the version of the rummageable and gds-api-adapters gems.  There was a conflict (with `rest-client`)when updating the gems, which I resolved by updating that gem specifically.  An earlier attempt to resolve it with `bundle update` resulted in many gem updates, and also broke the testsuite.

We also look up rummager using Plek under the name rummager instead of search, since that's now the canonical name.