### PR TITLE
Don't catch one error and trigger another

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -18,8 +18,6 @@ class SearchController < ApplicationController
       res = search_client.unified_search(q: @search_term, filter_manual: "service-manual")
       @results = res["results"].map { |r| SearchResult.new(r) }
     end
-  rescue GdsApi::BaseError => e
-    @results = ["HELP!"]
   end
 
   protected


### PR DESCRIPTION
Currently, if the call to rummager fails for any reason, the error is
caught, and @results is set to `["HELP!"]`.  This then fails in the
view, with `undefined method `link' for "HELP!"`.

Instead of trying to present a "fake" result list containing an error,
which will be unhelpful to users, and also get cached for a while, just
let the original error bubble up.  This will cause the app to give a 5xx
error page, which correctly tells the user to try again.  It might also
be caught by the cache in some cases and not even be shown to the user.