### PR TITLE
Bump slimmer for rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'gds-api-adapters', '18.3.0'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '8.1.0'
+  gem 'slimmer', '8.2.1'
 end
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
       libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
-    slimmer (8.1.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -207,7 +207,7 @@ DEPENDENCIES
   rspec-rails (= 2.11.0)
   rummageable (= 1.2.0)
   sass-rails (= 3.2.5)
-  slimmer (= 8.1.0)
+  slimmer (= 8.2.1)
   therubyracer (= 0.12.1)
   thin
   uglifier (= 1.2.6)


### PR DESCRIPTION
So we can track which application renders which page in analytics update
slimmer for a new version which outputs the rendering application.

This contains both https://github.com/alphagov/slimmer/pull/126 and https://github.com/alphagov/slimmer/pull/128
