### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rack-rewrite', '1.3.3'
 gem 'govuk_frontend_toolkit', '1.4.0'
 gem 'plek', '1.5.0'
 gem 'rummageable', '1.2.0'
-gem 'gds-api-adapters', '18.3.0'
+gem 'gds-api-adapters', '20.1.1'
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
@@ -20,7 +20,7 @@ end
 # in production environments by default.
 group :assets do
   gem 'sass-rails', '3.2.5'
-  gem 'therubyracer', '0.12.1', :platforms => :ruby
+  gem 'therubyracer', '0.12.2', :platforms => :ruby
   gem 'uglifier', '1.2.6'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.0.11)
-    gds-api-adapters (18.3.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -70,7 +70,7 @@ GEM
     journey (1.0.4)
     json (1.8.3)
     kgio (2.7.4)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.11)
     libwebsocket (0.1.3)
       addressable
     link_header (0.0.8)
@@ -92,7 +92,7 @@ GEM
     null_logger (0.0.1)
     plek (1.5.0)
     polyglot (0.3.5)
-    rack (1.4.6)
+    rack (1.4.7)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-rewrite (1.3.3)
@@ -165,7 +165,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    therubyracer (0.12.1)
+    therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
     thin (1.6.1)
@@ -183,7 +183,7 @@ GEM
       multi_json (~> 1.3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.6)
+    unf_ext (0.0.7.1)
     unicorn (4.3.1)
       kgio (~> 2.6)
       rack
@@ -197,7 +197,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 3.1.17)
   capybara (= 1.1.2)
-  gds-api-adapters (= 18.3.0)
+  gds-api-adapters (= 20.1.1)
   govuk_frontend_toolkit (= 1.4.0)
   logstasher (= 0.4.8)
   mocha (= 0.13.3)
@@ -208,7 +208,7 @@ DEPENDENCIES
   rummageable (= 1.2.0)
   sass-rails (= 3.2.5)
   slimmer (= 8.2.1)
-  therubyracer (= 0.12.1)
+  therubyracer (= 0.12.2)
   thin
   uglifier (= 1.2.6)
   unicorn (= 4.3.1)

--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -24,7 +24,7 @@ namespace :router do
     ].each do |path, type|
       begin
         @logger.info "Registering #{type} route #{path}"
-        @router_api.add_route(path, type, @app_id, :skip_commit => true)
+        @router_api.add_route(path, type, @app_id)
       rescue => e
         @logger.error "Error registering route: #{e.message}"
         raise
@@ -74,7 +74,7 @@ namespace :router do
     ].each do |path, type, destination|
       begin
         @logger.info "Registering #{type} redirect route from #{path} -> #{destination}"
-        @router_api.add_redirect_route(path, type, destination, "permanent", :skip_commit => true)
+        @router_api.add_redirect_route(path, type, destination, "permanent")
       rescue => e
         @logger.error "Error registering route: #{e.message}"
         raise


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

Includes a therubyracer bump to 0.12.2 for dependency
resolution reasons.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information