### PR TITLE
Remove section-related code

### DIFF
--- a/lib/search_result.rb
+++ b/lib/search_result.rb
@@ -1,18 +1,4 @@
 class SearchResult
-  SECTION_NAME_TRANSLATION = {
-    "life-in-the-uk" => "Life in the UK",
-    "council-tax" => "Council Tax",
-    "housing-benefits-grants-and-schemes" => "Housing benefits, grants and schemes",
-    "work-related-benefits-and-schemes" => "Work-related benefits and schemes",
-    "buying-selling-a-vehicle" => "Buying/selling a vehicle",
-    "owning-a-car-motorbike" => "Owning a car/motorbike",
-    "council-and-housing-association-homes" => "Council and housing association homes",
-    "animals-food-and-plants" => "Animals, food and plants",
-    "mot" => "MOT",
-    "mot-insurance" => "MOT insurance",
-    "Inside Government" => "Inside Government"
-  }
-
   attr_accessor :result
 
   def initialize(result)
@@ -31,27 +17,5 @@ class SearchResult
     define_method key do
       result[key.to_s]
     end
-  end
-
-  # Avoid the mundanity of creating these all by hand by making
-  # dynamic method and accessors.
-  %w(section subsection subsubsection).each do |key|
-    define_method "formatted_#{key}_name" do
-      mapped_name(send(key)) || humanized_name(send(key))
-    end
-
-    define_method key do
-      result[key]
-    end
-  end
-
-  protected
-
-  def mapped_name(var)
-    return SECTION_NAME_TRANSLATION[var] ? SECTION_NAME_TRANSLATION[var] : false
-  end
-
-  def humanized_name(name)
-    name.gsub('-', ' ').capitalize
   end
 end


### PR DESCRIPTION
Usage of `section` and `subsection` was removed in 2013: https://github.com/alphagov/design-principles/pull/29

This commit removes all unused code related to sections. This is so that we can remove the fields from rummager in the future.

Trello: https://trello.com/c/N0dU4k3G