### PR TITLE
Upgrade Slimmer, explicitly set 'wrapper' layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'gds-api-adapters', '23.2.2'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '8.2.1'
+  gem 'slimmer', '9.0.0'
 end
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
       libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
-    slimmer (8.2.1)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -207,7 +207,7 @@ DEPENDENCIES
   rspec-rails (= 2.11.0)
   rummageable (= 1.2.0)
   sass-rails (= 3.2.5)
-  slimmer (= 8.2.1)
+  slimmer (= 9.0.0)
   therubyracer (= 0.12.2)
   thin
   uglifier (= 1.2.6)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,9 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   before_filter :turn_off_report_a_problem
 
+  include Slimmer::Template
+  slimmer_template 'wrapper'
+
 protected
   def set_expiry(duration = 30.minutes)
     unless Rails.env.development?


### PR DESCRIPTION
This should be a no-op change to app behaviour. The Slimmer default was 'wrapper'
before the upgrade, and is not explicitly set.

Slimmer 9.0.0 switched to `core_layout` [1] as the default layout, which is the
modern/recommend layout. Apps not yet using `core_layout` should be explicitly
marked as such, so we can easily identify them as needing updating.

I had a quick look at what would be required to use a modern layout and it's not
immediately clear what static styles this app relies upon.

I think it might be safe to switch to `core_layout`, and that the layout doesn't
really matter to this app, as so many parts are complete HTML pages, or have
such heavy custom styling that it doesn't matter?

I'd appreciate someone with more experience of `design-principles` to look this over
(and if you could comment on the layout question in the previous paragraph, that would be
great).