### PR TITLE
Switch slimmer layout to the default

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,6 @@ class ApplicationController < ActionController::Base
   before_filter :turn_off_report_a_problem
 
   include Slimmer::Template
-  slimmer_template 'wrapper'
 
 protected
   def set_expiry(duration = 30.minutes)


### PR DESCRIPTION
This app doesn't depend on the usual GOV.UK grid/wrapper, and it doesn't
matter if it's using the `wrapper` layout or `core_layout`.

Switching away from `wrapper` gives us better visibility of which apps are
still using the legacy `wrapper` layout, so we can focus on migrating them.

I tested this change against @jabley's [`wraith` branch](https://github.com/alphagov/design-principles/pull/246), to ensure no visual changes across various sizes.