### PR TITLE
Add content_id to redirects

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -18,6 +18,7 @@ class PublishSpecialRoutesHelper
     logger.info("Registering redirect of '#{base_path}' -> '#{destination_path}'")
 
     redirect = {
+      "content_id" => content_id,
       "format" => "redirect",
       "publishing_app" => publishing_app,
       "update_type" => "major",


### PR DESCRIPTION
These redirects are supposed to have a content_id, but aren't being sent to the publishing-api.

These redirects are sent by `rake publishing_api:publish_special_routes`, which is _probably_ run after every deploy. A deploy to preview should confirm this.