### PR TITLE
Change title of service manual special route.

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -73,7 +73,7 @@ namespace :publishing_api do
         base_path: '/design-principles',
       },
       {
-        title: 'GDS Service Manual',
+        title: 'Service manual',
         description: '',
         content_id: '51dd8775-cd2a-4fb3-b6df-8ed03591122d',
         base_path: '/service-manual',


### PR DESCRIPTION
We are starting to refer to the service manual root by content_id in the new service manual, which expands in the title and the official title for the service manual is 'Service manual'.

This will require either the rake task `router:register` or `publishing_api:publish_special_routes` to be run when deployed.