### PR TITLE
[do-not-merge] Use correct service manual filter

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,7 +15,7 @@ class SearchController < ApplicationController
     if @search_term.blank?
       @results = []
     else
-      res = search_client.unified_search(q: @search_term, filter_manual: "service-manual")
+      res = search_client.unified_search(q: @search_term, filter_manual: "/service-manual")
       @results = res["results"].map { |r| SearchResult.new(r) }
     end
   end

--- a/spec/controller/search_controller_spec.rb
+++ b/spec/controller/search_controller_spec.rb
@@ -17,7 +17,7 @@ describe SearchController, :type => :controller do
 
   it "should pass our query parameter in to the search client" do
     controller.search_client.expects(:unified_search)
-                            .with(q: "search-term", filter_manual: "service-manual")
+                            .with(q: "search-term", filter_manual: "/service-manual")
                             .returns("results" => []).once
     do_search
   end


### PR DESCRIPTION
This requires https://github.com/alphagov/service-manual-publisher/pull/258 to be deployed to production first, and it needs guides to be reindexed.