### PR TITLE
make 'Start with user needs' clearer

### DIFF
--- a/app/views/root/designprinciples.html.erb
+++ b/app/views/root/designprinciples.html.erb
@@ -8,7 +8,7 @@
    <nav>
      <ol>
        <li>
-         <a href="#first"><span class="icon">1</span> <span class="caption">Start with needs*</span></a>
+         <a href="#first"><span class="icon">1</span> <span class="caption">Start with user needs</span></a>
        </li>
        <li>
          <a href="#second"><span class="icon">2</span> <span class="caption">Do less</span></a>
@@ -44,8 +44,7 @@
      <li class="principle">
       <article>
         <hgroup>
-          <h1 id="first">Start with needs*</h1>
-          <h2>*user needs not government needs</h2>
+          <h1 id="first">Start with user needs</h1>
         </hgroup>
 
          <div class="outline">


### PR DESCRIPTION
As a principle 'start with needs*' is not clear - 'start with user needs' is clearer.

Not sure why we need to state 'not government needs' - as the government is not a user. If there are users of the service in government, their needs should obviously be considered too.