### PR TITLE
Change "start with needs" to "start with user needs"

### DIFF
--- a/app/views/root/designprinciples.html.erb
+++ b/app/views/root/designprinciples.html.erb
@@ -8,7 +8,7 @@
    <nav>
      <ol>
        <li>
-         <a href="#first"><span class="icon">1</span> <span class="caption">Start with needs*</span></a>
+         <a href="#first"><span class="icon">1</span> <span class="caption">Start with user needs</span></a>
        </li>
        <li>
          <a href="#second"><span class="icon">2</span> <span class="caption">Do less</span></a>
@@ -44,8 +44,7 @@
      <li class="principle">
       <article>
         <hgroup>
-          <h1 id="first">Start with needs*</h1>
-          <h2>*user needs not government needs</h2>
+          <h1 id="first">Start with user needs</h1>
         </hgroup>
 
          <div class="outline">

--- a/app/views/root/designprinciples.html.erb
+++ b/app/views/root/designprinciples.html.erb
@@ -3,7 +3,7 @@
  <div id="wrapper" class="design-principles">
   <header class="gds-principles">
     <h1>Government Digital Service <strong>Design Principles</strong></h1>
-    <p>Listed below are our design principles and examples of how we’ve used them so far. These build on, and add to, our original <a href="http://www.flickr.com/photos/benterrett/7041509709/">7 digital principles</a>.</p>
+    <p>Listed below are our design principles and examples of how we’ve used them so far.</p>
   </header>
    <nav>
      <ol>
@@ -39,7 +39,7 @@
        </li>
      </ol>
    </nav>
-   
+
    <ol class="principles">
      <li class="principle">
       <article>
@@ -63,12 +63,12 @@
          </div>
         </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="second">Do less</h1>
-       
+
          <div class="outline">
            <p>
             Government should only do what only government can do. If we’ve
@@ -86,12 +86,12 @@
          </div>
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="third">Design with data</h1>
-       
+
          <div class="outline">
            <p>
             In most cases, we can learn from real world behaviour by looking at
@@ -109,12 +109,12 @@
          </div>
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="fourth">Do the hard work to make it simple</h1>
-       
+
          <div class="outline">
            <p>
             Making something look simple is easy. Making something simple to
@@ -131,12 +131,12 @@
          </div>
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="fifth">Iterate. Then iterate again.</h1>
-       
+
          <div class="outline">
            <p>
             The best way to build good services is to start small and iterate
@@ -162,12 +162,12 @@
          </div>
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="sixth">This is for everyone</h1>
-       
+
          <div class="outline">
            <p>
             Accessible design is good design. Everything we build should be as
@@ -183,12 +183,12 @@
              <li><a href="https://accessibility.blog.gov.uk/2016/05/16/consider-the-range-of-people-that-will-use-your-product-or-service/">Consider the range of people that will use your product or service</a>, by&nbsp;Alistair&nbsp;Duggin</li>
              <li><a href="https://accessibility.blog.gov.uk/2016/05/17/hope-inspiration-and-inclusion/">Hope, inspiration and inclusion</a>, by&nbsp;Steven&nbsp;Mark</li>
              <li><a href="https://gds.blog.gov.uk/2012/10/01/building-for-inclusion/">Building for inclusion</a>, by&nbsp;Léonie&nbsp;Watson</li>
-             
+
            </ul>
          </div>
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
          <h1 id="seventh">Understand context</h1>
@@ -207,12 +207,12 @@
           </div>
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="eighth">Build digital services, not websites</h1>
-       
+
          <div class="outline">
            <p>
             A service is something that helps people to do something. Our job
@@ -230,12 +230,12 @@
          </div>
        </article>
      </li>
-   
+
      <li class="principle">
        <article>
-       
+
          <h1 id="ninth">Be consistent, not uniform</h1>
-       
+
          <div class="outline">
            <p>
             We should use the same language and the same design patterns
@@ -257,7 +257,7 @@
         </div>
        </article>
      </li>
-   
+
       <li class="principle">
         <article>
 

--- a/spec/integration/designprinciples_spec.rb
+++ b/spec/integration/designprinciples_spec.rb
@@ -5,7 +5,7 @@ describe "The designprinciples page", type: :feature do
     visit "/design-principles"
 
     page.should have_content("Design Principles")
-    page.should have_content("Start with needs")
+    page.should have_content("Start with user needs")
   end
 end
 


### PR DESCRIPTION
Copying from #272 opened by @joelanman:

As a principle 'start with needs*' is not clear - 'start with user needs' is clearer.

Not sure why we need to state 'not government needs' - as the government is not a user. If there are users of the service in government, their needs should obviously be considered too.

This PR fixes the test missing from #272.