### PR TITLE
Fix non-typographic apostrophe

### DIFF
--- a/app/views/root/designprinciples.html.erb
+++ b/app/views/root/designprinciples.html.erb
@@ -52,7 +52,7 @@
             Service design starts with identifying user needs. If you don’t
             know what the user needs are, you won’t build the right thing. Do
             research, analyse data, talk to users. Don’t make assumptions. Have
-            empathy for users, and remember that what they ask for isn't
+            empathy for users, and remember that what they ask for isn’t
             always what they need.
           </p>
           <ul>


### PR DESCRIPTION
> “Smart quotes,” the correct quotation marks and apostrophes, are curly or sloped. "Dumb quotes," or straight quotes, are a vestigial constraint from typewriters when using one key for two different marks helped save space on a keyboard.

– http://smartquotesforsmartpeople.com

***

Introduced in 59faf06c2a51fbdd3d152e9d04905d7a0db2cb0f