### PR TITLE
Update gds-api-adapters gem to get latest special route publishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'unicorn', '4.3.1'
 gem 'logstasher', '0.4.8'
 gem 'govuk_frontend_toolkit', '1.4.0'
 gem 'plek', '1.11.0'
-gem 'gds-api-adapters', '34.1.0'
+gem 'gds-api-adapters', '41.2.0'
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.0.1)
     execjs (2.7.0)
-    gds-api-adapters (34.1.0)
+    gds-api-adapters (41.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -191,7 +191,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 3.1.17)
   capybara
-  gds-api-adapters (= 34.1.0)
+  gds-api-adapters (= 41.2.0)
   govuk_frontend_toolkit (= 1.4.0)
   logstasher (= 0.4.8)
   mocha (= 0.13.3)
@@ -205,3 +205,6 @@ DEPENDENCIES
   thin
   uglifier (= 1.2.6)
   unicorn (= 4.3.1)
+
+BUNDLED WITH
+   1.14.5


### PR DESCRIPTION
Update the API adapter gem so that special route publishing contains the new fields added to the `special_route` schema.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing