### PR TITLE
Send update_type with put_content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'unicorn', '4.3.1'
 gem 'logstasher', '0.4.8'
 gem 'govuk_frontend_toolkit', '1.4.0'
 gem 'plek', '1.11.0'
-gem 'gds-api-adapters', '41.2.0'
+gem 'gds-api-adapters', '47.2'
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,12 +44,12 @@ GEM
       xpath (~> 2.0)
     daemons (1.2.4)
     diff-lcs (1.2.5)
-    domain_name (0.5.20160615)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     eventmachine (1.2.0.1)
     execjs (2.7.0)
-    gds-api-adapters (41.2.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -60,7 +60,7 @@ GEM
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.3)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     journey (1.0.4)
@@ -92,7 +92,7 @@ GEM
     polyglot (0.3.5)
     power_assert (0.4.1)
     rack (1.4.7)
-    rack-cache (1.6.1)
+    rack-cache (1.7.0)
       rack (>= 0.4)
     rack-ssl (1.3.4)
       rack
@@ -118,7 +118,7 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     ref (2.0.0)
-    rest-client (2.0.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -177,7 +177,7 @@ GEM
       multi_json (~> 1.3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     unicorn (4.3.1)
       kgio (~> 2.6)
       rack
@@ -191,7 +191,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 3.1.17)
   capybara
-  gds-api-adapters (= 41.2.0)
+  gds-api-adapters (= 47.2)
   govuk_frontend_toolkit (= 1.4.0)
   logstasher (= 0.4.8)
   mocha (= 0.13.3)
@@ -207,4 +207,4 @@ DEPENDENCIES
   unicorn (= 4.3.1)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -34,7 +34,7 @@ class PublishSpecialRoutesHelper
     }
 
     publishing_api.put_content(content_id, redirect)
-    publishing_api.publish(content_id, "major")
+    publishing_api.publish(content_id)
   end
 
 private


### PR DESCRIPTION
https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk