### PR TITLE
Deploy master branch builds to integration correctly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,8 +32,7 @@ node {
       }
 
       stage("Deploy to integration") {
-        build job: 'integration-app-deploy',
-        parameters: [string(name: GOVUK_APP_NAME, value: 'release_' + env.BUILD_NUMBER)]
+        govuk.deployIntegration(GOVUK_APP_NAME, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER, 'deploy')
       }
     }
 


### PR DESCRIPTION
The previous version would send the wrong parameters, ending up with
`TARGET_APPLICATION` set to `-- Choose an app` instead of
`designprinciples`.  If we use the govuk.deployIntegration function
from the govuk jenkins library we avoid this problem.

We might want to look at replacing the entire jenkinsfile with a call
to `govuk.buildProject()`, but it's not clear if our existing script
wants all of that.