### PR TITLE
Fix errors in links in styleguide sections

### DIFF
--- a/app/views/root/_styleguide_sections.html.erb
+++ b/app/views/root/_styleguide_sections.html.erb
@@ -1,13 +1,13 @@
   <nav>
     <ul class="sections">
       <li>
-        <%= nav_link_to('/design-principles/styleguide', {class: "gov-uk"}) do %>
+        <%= nav_link_to('/design-principles/style-guide', {class: "gov-uk"}) do %>
           <span class="icon">1, 2</span>
           <span class="caption">GOV.UK</span>
         <% end %>
       </li>
       <li>
-        <%= nav_link_to('/design-principes/mainstream', {class: "Mainstream content types"}) do %>
+        <%= nav_link_to('/design-principles/mainstream', {class: "Mainstream content types"}) do %>
           <span class="icon">3</span>
           <span class="caption">Mainstream content types</span>
         <% end %>


### PR DESCRIPTION
In 0098a85f4dc4a80921f6d9a3143f74cd46dde500 we simplified the paths in
the styleguide_sections partial, but we introduced a typo in one (
`design-principes` should be `design-principles`) and in another we
should have replaced the old controller action name, `styleguide`, with
the actual path, `style-guide`.