### PR TITLE
Redirect /design-principles to new location

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -2,6 +2,7 @@ class RootController < ApplicationController
   before_filter :set_expiry
 
   def designprinciples
+    redirect_to "/guidance/government-design-principles"
   end
 
   def styleguide


### PR DESCRIPTION
We can't set up a route in the `publishing-api` since the existing route is a prefix route and this app also handles other `/design-principles/*` routes.