### PR TITLE
Redirect design principles

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,14 +6,8 @@ Rails.application.routes.draw do
 
   get "/design-principles/style-guide", :to => "styleguide#index"
 
-  # redirect the old URLs
-  get "/design-principles/mainstream", :to => redirect("/design-principles/style-guide")
-  get "/design-principles/insidegovernment", :to => redirect("/design-principles/style-guide/writing-for-govuk")
-  get "/design-principles/detailedguides", :to => redirect("/design-principles/style-guide/detailed-guides")
   get "/design-principles/accessiblepdfs", :to => "root#accessiblepdfs"
   get "/design-principles/performanceframework", :to => "root#performanceframework"
-  get "/design-principles/whatsnew", :to => redirect("/design-principles/style-guide/whats-new")
-  get "/design-principles/seo", :to => redirect("/design-principles/style-guide/writing-for-govuk#seo")
 
   root :to => redirect("/design-principles")
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,5 @@ Rails.application.routes.draw do
   get "/design-principles/whatsnew", :to => redirect("/design-principles/style-guide/whats-new")
   get "/design-principles/seo", :to => redirect("/design-principles/style-guide/writing-for-govuk#seo")
 
-  get "/:prefix/search", :to => 'search#index'
   root :to => redirect("/design-principles")
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -70,21 +70,6 @@ namespace :publishing_api do
     [
       {
         title: "GDS Design Principles",
-        content_id: "52028eb3-c0ef-412d-a986-2fc0a342569e",
-        base_path: "/design-principles/mainstream",
-      },
-      {
-        title: "GDS Design Principles",
-        content_id: "a82e1adb-637d-4cfe-986b-b65dd7fe4f48",
-        base_path: "/design-principles/insidegovernment",
-      },
-      {
-        title: "GDS Design Principles",
-        content_id: "93554c24-c13c-49ed-b5de-759a4cb0a7b8",
-        base_path: "/design-principles/detailedguides",
-      },
-      {
-        title: "GDS Design Principles",
         content_id: "aa5431bb-2f2e-4e6a-a819-d25c5ba6b5d0",
         base_path: "/design-principles/accessiblepdfs",
       },
@@ -92,16 +77,6 @@ namespace :publishing_api do
         title: "GDS Design Principles",
         content_id: "74a68f1b-d86d-42e4-b79d-05ff5b932265",
         base_path: "/design-principles/performanceframework",
-      },
-      {
-        title: "GDS Design Principles",
-        content_id: "185e6998-106e-494f-87fd-46d095ec32dc",
-        base_path: "/design-principles/whatsnew",
-      },
-      {
-        title: "GDS Design Principles",
-        content_id: "ce017d8c-7d39-4a8c-aed9-af236edd656a",
-        base_path: "/design-principles/seo",
       },
       {
         title: "GDS Design Principles",
@@ -118,6 +93,13 @@ namespace :publishing_api do
 
     [
       %w(8b7b20d4-4144-4f52-922a-2fec92e1a346 /design-principles exact /guidance/government-design-principles),
+
+      %w(52028eb3-c0ef-412d-a986-2fc0a342569e /design-principles/mainstream exact /design-principles/style-guide),
+      %w(a82e1adb-637d-4cfe-986b-b65dd7fe4f48 /design-principles/insidegovernment exact /design-principles/style-guide/writing-for-govuk),
+      %w(93554c24-c13c-49ed-b5de-759a4cb0a7b8 /design-principles/detailedguides exact /design-principles/style-guide/detailed-guides),
+      %w(185e6998-106e-494f-87fd-46d095ec32dc /design-principles/whatsnew exact /design-principles/style-guide/whats-new),
+      %w(ce017d8c-7d39-4a8c-aed9-af236edd656a /design-principles/seo exact /design-principles/style-guide/writing-for-govuk#seo),
+
       %w(b9b74acd-58bd-4e6b-8318-e6926a25c84d /designprinciples prefix /design-principles),
       %w(d0e21ccf-530c-4326-93a7-5badfa087754 /designprinciples/styleguide prefix /topic/government-digital-guidance/content-publishing),
       %w(f17a55b1-cffd-4e4f-b6e3-47ec5e2e8fd0 /design-principles/style-guide/policy-advisory-groups prefix /design-principles/style-guide/groups),

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -6,7 +6,8 @@ class PublishSpecialRoutesHelper
   def publish_special_route(special_route)
     special_route_publisher.publish(
       {
-        type: 'prefix',
+        type: "exact",
+        description: "",
         publishing_app: publishing_app,
         rendering_app: 'designprinciples'
       }.merge(special_route)
@@ -68,21 +69,55 @@ namespace :publishing_api do
 
     [
       {
-        title: 'GDS Design Principles',
-        description: '',
-        content_id: '8b7b20d4-4144-4f52-922a-2fec92e1a346',
-        base_path: '/design-principles',
+        title: "GDS Design Principles",
+        content_id: "52028eb3-c0ef-412d-a986-2fc0a342569e",
+        base_path: "/design-principles/mainstream",
+      },
+      {
+        title: "GDS Design Principles",
+        content_id: "a82e1adb-637d-4cfe-986b-b65dd7fe4f48",
+        base_path: "/design-principles/insidegovernment",
+      },
+      {
+        title: "GDS Design Principles",
+        content_id: "93554c24-c13c-49ed-b5de-759a4cb0a7b8",
+        base_path: "/design-principles/detailedguides",
+      },
+      {
+        title: "GDS Design Principles",
+        content_id: "aa5431bb-2f2e-4e6a-a819-d25c5ba6b5d0",
+        base_path: "/design-principles/accessiblepdfs",
+      },
+      {
+        title: "GDS Design Principles",
+        content_id: "74a68f1b-d86d-42e4-b79d-05ff5b932265",
+        base_path: "/design-principles/performanceframework",
+      },
+      {
+        title: "GDS Design Principles",
+        content_id: "185e6998-106e-494f-87fd-46d095ec32dc",
+        base_path: "/design-principles/whatsnew",
+      },
+      {
+        title: "GDS Design Principles",
+        content_id: "ce017d8c-7d39-4a8c-aed9-af236edd656a",
+        base_path: "/design-principles/seo",
+      },
+      {
+        title: "GDS Design Principles",
+        content_id: "7672ae7d-6efb-4816-bd74-c49a6cb43f04",
+        base_path: "/design-principles/style-guide.atom",
       },
       {
         title: 'Transformation programme',
-        description: '',
         content_id: '00573998-7254-407c-ba28-776dd222cda3',
         base_path: '/transformation',
+        type: "prefix",
       }
     ].each(&helper.method(:publish_special_route))
 
     [
-      # Redirections because the slugs changed.
+      %w(8b7b20d4-4144-4f52-922a-2fec92e1a346 /design-principles exact /guidance/government-design-principles),
       %w(b9b74acd-58bd-4e6b-8318-e6926a25c84d /designprinciples prefix /design-principles),
       %w(d0e21ccf-530c-4326-93a7-5badfa087754 /designprinciples/styleguide prefix /topic/government-digital-guidance/content-publishing),
       %w(f17a55b1-cffd-4e4f-b6e3-47ec5e2e8fd0 /design-principles/style-guide/policy-advisory-groups prefix /design-principles/style-guide/groups),


### PR DESCRIPTION
`/design-principles` is being redirects to `/guidance/government-design-principles`, but the other routes will be left as they are by creating `exact` routes for them.