### PR TITLE
Remove patch for action pack vulnerability

### DIFF
--- a/config/initializers/param_parsers.rb
+++ b/config/initializers/param_parsers.rb
@@ -1,4 +1,0 @@
-# Turn off XML parsing:
-# https://groups.google.com/forum/#!topic/rubyonrails-security/61bkgvnSGTQ/discussion
-ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::XML)
-ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::JSON)


### PR DESCRIPTION
Rails now includes a fix for this CVE, so this patch can be removed. The current approach is 
causing the Rails 5 upgrade to error. https://github.com/alphagov/design-principles/pull/297

We could take an alternate route where we continue to disable these parsers, though I think I favour defaulting to standard rails configs. 

Here is the commit in Rails that resolves this:
https://github.com/rails/rails/commit/46e0d2397ea10a0bf380926c9fe3cfcf14d5c499

Thoughts?